### PR TITLE
elasticPassthrough with either arrays or objects 

### DIFF
--- a/lib/routes/_search.js
+++ b/lib/routes/_search.js
@@ -25,6 +25,7 @@ function decorateWithPrefix(queryObj) {
  * Return a function for `expectJSON` to evaluate which
  * will query Elastic with the payload from the client's
  * request
+ * 
  * Check if query object is an array or an object
  *
  * @param  {object} queryObj

--- a/lib/routes/_search.js
+++ b/lib/routes/_search.js
@@ -25,6 +25,7 @@ function decorateWithPrefix(queryObj) {
  * Return a function for `expectJSON` to evaluate which
  * will query Elastic with the payload from the client's
  * request
+ * Check if query object is an array or an object
  *
  * @param  {object} queryObj
  * @return {function}

--- a/lib/routes/_search.js
+++ b/lib/routes/_search.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const elastic = require('../services/elastic'),
+const _ = require('lodash'),
+  elastic = require('../services/elastic'),
   helpers = require('../services/elastic-helpers'),
   responses = require('../services/responses');
 
@@ -30,7 +31,11 @@ function decorateWithPrefix(queryObj) {
  */
 function elasticPassthrough(queryObj) {
   return function () {
-    return elastic.client.search(decorateWithPrefix(queryObj));
+    if (_.isArray(queryObj.body)) {
+      return elastic.client.msearch(decorateWithPrefix(queryObj));
+    } else {
+      return elastic.client.search(decorateWithPrefix(queryObj));
+    }
   };
 }
 

--- a/lib/routes/_search.test.js
+++ b/lib/routes/_search.test.js
@@ -24,7 +24,8 @@ describe(_.startCase(filename), function () {
   let sandbox, router = createMockRouter();
 
   elastic.setup({
-    search: _.noop
+    search: _.noop,
+    msearch: _.noop
   });
 
   beforeEach(function () {
@@ -60,6 +61,22 @@ describe(_.startCase(filename), function () {
       var callback = fn({query: 'query'});
 
       expect(callback).to.throw(Error);
+    });
+
+    it('uses msearch when body is an array', function () {
+      var callback = fn({index: 'pages', body: [{query: 'query'}]});
+
+      sandbox.stub(elastic.client, 'msearch');
+      callback();
+      expect(elastic.client.msearch.called).to.be.true;
+    });
+
+    it('uses search when body is an object', function () {
+      var callback = fn({index: 'pages', body: {query: 'query'}});
+
+      sandbox.stub(elastic.client, 'search');
+      callback();
+      expect(elastic.client.search.called).to.be.true;
     });
   });
 

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -16,6 +16,7 @@ function createFakeClientClass() {
   return {
     bulk: _.noop,
     search: _.noop,
+    msearch: _.noop,
     delete: _.noop,
     index: _.noop,
     ping: _.noop,


### PR DESCRIPTION
`executeMultipleSearchRequests` in the query service expects either a query array or a query object depending on if it is being run on the server or the client. When querying Elastic, we need to check this to know if we need to use multi search or search on the ElasticSearch client. 