### PR TITLE
cleanup docs and add support for ES update documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 node_modules/
 npm-debug.log
 coverage/

--- a/lib/delete.js
+++ b/lib/delete.js
@@ -9,14 +9,15 @@ var log = require('./services/log').withStandardPrefix(__dirname);
  * Test for @scheduled when a delete is run and update
  * the page list entry
  * @param  {Array} ops
+ * @returns {Promise}
  */
 function onDelete(ops) {
   var scheduledOps = _.filter(ops, op => {
-    return op.key.indexOf(SCHEDULED) > -1 && op.key.indexOf('/pages/') > -1
+    return op.key.indexOf(SCHEDULED) > -1 && op.key.indexOf('/pages/') > -1;
   });
 
   if (scheduledOps.length) {
-    return removeScheduled(scheduledOps[0].key.replace(SCHEDULED, ''))
+    return removeScheduled(scheduledOps[0].key.replace(SCHEDULED, ''));
   }
 }
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -7,7 +7,6 @@ const _ = require('lodash'),
  * Publish hook
  *
  * @param  {Object} payload
- * @return {Promise}
  */
 function publish(payload) {
   _.each(setup.handlers, (handler) => {

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -165,7 +165,7 @@ function convertOpValuesPropertyToString(propertyName, ops) {
  * @param {string} options.index
  * @param {string} options.type
  * @param {Array}  options.ops
- * @param {boolean} [options.update]  flag to update rather than replace the document
+ * @param {string} [options.action] defaults to `index`, can use `create`, `index`, `update`, `delete`
  * @returns {Array}
  */
 function convertRedisBatchtoElasticBatch(options) {
@@ -173,7 +173,7 @@ function convertRedisBatchtoElasticBatch(options) {
     index = options.index,
     type = options.type,
     ops = options.ops,
-    update = options.update;
+    action = options.action || 'index'; // default to overwrite document
 
   _.each(ops, function (op) {
     if (_.isString(op.value)) {
@@ -189,8 +189,8 @@ function convertRedisBatchtoElasticBatch(options) {
       }
 
       bulkOps.push(
-        update ? { update: indexOp } : { index: indexOp },
-        update ? { doc: op.value } : op.value
+        _.set({}, action, indexOp),
+        action === 'update' ? { doc: op.value } : op.value
       );
     } else {
       log('warn', 'Unhandled batch operation:', op);

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -161,13 +161,19 @@ function convertOpValuesPropertyToString(propertyName, ops) {
 /**
  * Convert Redis batch operations to Elasticsearch batch operations
  *
- * @param {string} index
- * @param {string} type
- * @param {Array} ops
+ * @param {object} options
+ * @param {string} options.index
+ * @param {string} options.type
+ * @param {Array}  options.ops
+ * @param {boolean} [options.update]  flag to update rather than replace the document
  * @returns {Array}
  */
-function convertRedisBatchtoElasticBatch(index, type, ops) {
-  let bulkOps = [];
+function convertRedisBatchtoElasticBatch(options) {
+  let bulkOps = [],
+    index = options.index,
+    type = options.type,
+    ops = options.ops,
+    update = options.update;
 
   _.each(ops, function (op) {
     if (_.isString(op.value)) {
@@ -182,8 +188,9 @@ function convertRedisBatchtoElasticBatch(index, type, ops) {
         indexOp._id = op.key;
       }
 
-      bulkOps.push({ index: indexOp },
-        op.value
+      bulkOps.push(
+        update ? { update: indexOp } : { index: indexOp },
+        update ? { doc: op.value } : op.value
       );
     } else {
       log('warn', 'Unhandled batch operation:', op);
@@ -252,22 +259,23 @@ function normalizeOpValuesWithMapping(mapping, ops) {
  * (which is passed in by the user) to filter the ops down to what
  * is necessary for a specific index.
  *
- * @param  {Array}    batchOps
- * @param  {Object}   mappings
- * @param  {String}   indexName
- * @param  {Function} fn
- * @return {Promise}
+ * @param  {Array}    batchOps      db operations
+ * @param  {Object}   mappings      keys are index names, and values are index mapping settings
+ * @param  {String}   indexName     name of the elastic search index
+ * @param  {Function} opsTransform  function given batchOps that returns a Promise or object
+ * @return {Promise.<[[{ops: {}, mapping: {}, typeName: string}]]>}
  */
-function applyOpFilters(batchOps, mappings, indexName, fn) {
+function applyOpFilters(batchOps, mappings, indexName, opsTransform) {
   indexName = stripPrefix(indexName); // Trim the prefix off the index for comparing against mapping names
 
   return bluebird.all(_.map(_.pick(mappings, indexName), function (types) {
     return bluebird.all(_.map(types, function (mapping, typeName) {
-      return bluebird.resolve({
-        ops: fn(batchOps),
-        mapping: mapping, // TODO: May not need to return mapping
-        typeName: typeName
-      });
+      return bluebird.resolve(opsTransform(batchOps))
+        .then(transformedOps => ({
+          ops: transformedOps,
+          mapping: mapping, // TODO: May not need to return mapping
+          typeName: typeName
+        }));
     }));
   }));
 }

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -166,6 +166,7 @@ function convertOpValuesPropertyToString(propertyName, ops) {
  * @param {string} options.type
  * @param {Array}  options.ops
  * @param {string} [options.action] defaults to `index`, can use `create`, `index`, `update`, `delete`
+ * @throws will throw an error if options.action is not supported
  * @returns {Array}
  */
 function convertRedisBatchtoElasticBatch(options) {
@@ -181,17 +182,29 @@ function convertRedisBatchtoElasticBatch(options) {
     }
 
     if (op.type === 'put') {
-      let indexOp = { _index: index, _type: type };
+      let indexOp = { _index: index, _type: type },
+        requestMetadata = {},
+        requestBody;
 
       // key is optional; if missing, an id will be generated that is unique across all shards
       if (op.key) {
         indexOp._id = op.key;
       }
-
-      bulkOps.push(
-        _.set({}, action, indexOp),
-        action === 'update' ? { doc: op.value } : op.value
-      );
+      bulkOps.push(_.set(requestMetadata, action, indexOp));
+      switch (action) {
+        case 'index':
+        case 'create':
+          requestBody = op.value;
+          break;
+        case 'update':
+          requestBody = { doc: op.value };
+          break;
+        case 'delete':
+          return; // no request body for delete
+        default:
+          throw new Error(`${action} is not supported`);
+      }
+      bulkOps.push(requestBody);
     } else {
       log('warn', 'Unhandled batch operation:', op);
     }

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -52,7 +52,19 @@ describe(_.startCase(filename), function () {
       it('allows for update', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops, update: true})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'type' } }, {doc: {}}]);
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'update'})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'type' } }, {doc: {}}]);
+      });
+
+      it('allows for delete', function () {
+        var ops = [{ value: '{}', type: 'put', key: 'key' }];
+
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'delete'})).to.deep.equal([{ delete: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
+      });
+
+      it('allows for create', function () {
+        var ops = [{ value: '{}', type: 'put', key: 'key' }];
+
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'create'})).to.deep.equal([{ create: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
       });
     });
 

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -58,13 +58,19 @@ describe(_.startCase(filename), function () {
       it('allows for delete', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops, action: 'delete'})).to.deep.equal([{ delete: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'delete'})).to.deep.equal([{ delete: { _id: 'key', _index: 'index', _type: 'type' } }]);
       });
 
       it('allows for create', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
         expect(fn({index: 'index', type: 'type', ops: ops, action: 'create'})).to.deep.equal([{ create: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
+      });
+
+      it('throws on unsupported action', function () {
+        var ops = [{ value: '{}', type: 'put', key: 'key' }];
+
+        expect(fn.bind(null, {index: 'index', type: 'type', ops: ops, action: 'someUnsupportedAction'})).to.throw('someUnsupportedAction is not supported');
       });
     });
 

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -28,25 +28,31 @@ describe(_.startCase(filename), function () {
       it('returns an array of ops if type property equals "put" with a JSON string', function () {
         var ops = [{ value: '{}', type: 'put' }];
 
-        expect(fn('index', 'type', ops)).to.deep.equal([{ index: { _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _index: 'index', _type: 'type' } }, {}]);
       });
 
       it('returns an array of ops if type property equals "put" with a JS object', function () {
         var ops = [{ value: {}, type: 'put' }];
 
-        expect(fn('index', 'type', ops)).to.deep.equal([{ index: { _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _index: 'index', _type: 'type' } }, {}]);
       });
 
       it('assigns a "key" property if one is defined in the op', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn('index', 'type', ops)).to.deep.equal([{ index: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
       });
 
       it('assigns a "key" property if one is defined in the op', function () {
         var ops = [{ value: '{}', type: 'get', key: 'key' }];
 
-        expect(fn('index', 'type', ops)).to.deep.equal([]);
+        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([]);
+      });
+
+      it('allows for update', function () {
+        var ops = [{ value: '{}', type: 'put', key: 'key' }];
+
+        expect(fn({index: 'index', type: 'type', ops: ops, update: true})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'type' } }, {doc: {}}]);
       });
     });
 


### PR DESCRIPTION
This allows for updating elastic documents which is desirable when an index contains some of its data from a component and that component is updated. For example when an article within a page is updated; we would like to keep the pageUri, which the article does not know.