### PR TITLE
Add refresh param to update

### DIFF
--- a/lib/routes/_update.js
+++ b/lib/routes/_update.js
@@ -32,9 +32,9 @@ function validateUpdateRequest(updateBody) {
  */
 function elasticPassthrough(updateBody) {
   return function () {
-    var { index, type, id, body } = validateUpdateRequest(updateBody);
+    var { index, type, id, body, refresh } = validateUpdateRequest(updateBody);
 
-    return elastic.update(index, type, id, body);
+    return elastic.update(index, type, id, body, refresh);
   };
 }
 

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -478,17 +478,16 @@ function getDocument(index, type, id) {
  * @param  {string} type
  * @param  {string} id
  * @param  {object} data
+ * @param  {Boolean} refresh
  * @return {Promise}
  */
-function update(index, type, id, data) {
+function update(index, type, id, data, refresh = false) { // eslint-disable-line max-params
   if (!data) {
     throw new Error('Updating a page requires a data object');
   }
 
   return client.update({
-    index: index,
-    type: type,
-    id: id,
+    index, type, id, refresh,
     body: {
       doc: data
     }

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -483,7 +483,7 @@ function getDocument(index, type, id) {
  */
 function update(index, type, id, data, refresh = false) { // eslint-disable-line max-params
   if (!data) {
-    throw new Error('Updating a page requires a data object');
+    throw new Error('Updating an Elastic document requires a data object');
   }
 
   return client.update({

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -354,6 +354,14 @@ describe(_.startCase(filename), function () {
           expect(client.update.calledOnce).to.be.true;
         });
     });
+
+    it('calls the update method provided by the ES client with refresh param', function () {
+      client.update.returns(Promise.resolve('ES Client `update` called'));
+      return fn('pages', 'general', 'site/pages/foo', {}, true)
+        .then(function () {
+          expect(client.update.calledWith({ index: 'pages', type: 'general', id: 'site/pages/foo', body: {doc: {}}, refresh: true})).to.be.true;
+        });
+    });
   });
 
   describe('validateIndices', function () {


### PR DESCRIPTION
Sometimes update requests will need a refresh param so that the updated document appears in search results immediately.