### PR TITLE
Retry On Conflict

### DIFF
--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -190,21 +190,29 @@ function convertRedisBatchtoElasticBatch(options) {
       if (op.key) {
         indexOp._id = op.key;
       }
-      bulkOps.push(_.set(requestMetadata, action, indexOp));
+
       switch (action) {
         case 'index':
         case 'create':
           requestBody = op.value;
           break;
         case 'update':
+          indexOp._retry_on_conflict = 3; // Set a default retry value
           requestBody = { doc: op.value };
           break;
         case 'delete':
-          return; // no request body for delete
+          break;
         default:
           throw new Error(`${action} is not supported`);
       }
-      bulkOps.push(requestBody);
+
+      // Push the operation in before the request body
+      bulkOps.push(_.set(requestMetadata, action, indexOp));
+
+      // We may not have a request body if the action was `delete`
+      if (requestBody) {
+        bulkOps.push(requestBody);
+      }
     } else {
       log('warn', 'Unhandled batch operation:', op);
     }

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -52,7 +52,7 @@ describe(_.startCase(filename), function () {
       it('allows for update', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops, action: 'update'})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'type' } }, {doc: {}}]);
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'update'})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'type', _retry_on_conflict: 3 } }, {doc: {}}]);
       });
 
       it('allows for delete', function () {


### PR DESCRIPTION
For batch updates add in the `_retry_on_conflict` field to make sure changes in quick succession don't throw errors