### PR TITLE
Mapping Analyzers

### DIFF
--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -182,7 +182,7 @@ function addSettings(index, settings) {
     .then(function (exists) {
       if (exists) {
         return client.indices.close({index})
-          .then((resp) => { console.log(resp); return module.exports.putSettings(index, settings)})
+          .then((resp) => module.exports.putSettings(index, settings))
           .then(() => client.indices.open({index}))
       } else {
         log('warn', 'Could not put settings for index', index, 'because it does not exist');

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -181,7 +181,9 @@ function addSettings(index, settings) {
   return module.exports.existsIndex(index)
     .then(function (exists) {
       if (exists) {
-        return module.exports.putSettings(index, settings);
+        return client.indices.close({index})
+          .then((resp) => { console.log(resp); return module.exports.putSettings(index, settings)})
+          .then(() => client.indices.open({index}))
       } else {
         log('warn', 'Could not put settings for index', index, 'because it does not exist');
         return bluebird.resolve();
@@ -434,19 +436,19 @@ function validateIndices(mappings, settings, prefix) {
     });
   }))
   .then(function () {
-    return bluebird.all(_.reduce(mappings, function (list, types, index) {
-      return list.concat(_.map(types, function (mapping, type) {
-        return module.exports.createMappingIfNone(createIndexName(index, prefix), type, mapping);
-      }));
-    }, []));
-  })
-  .then(function () {
     return bluebird.all(_.map(mappings, function (list, index) {
       if (settings && settings[index]) {
         return module.exports.addSettings(createIndexName(index, prefix), settings[index]);
       }
       return bluebird.resolve();
     }));
+  })
+  .then(function () {
+    return bluebird.all(_.reduce(mappings, function (list, types, index) {
+      return list.concat(_.map(types, function (mapping, type) {
+        return module.exports.createMappingIfNone(createIndexName(index, prefix), type, mapping);
+      }));
+    }, []));
   });
 }
 

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -32,7 +32,9 @@ function createFakeClientClass() {
       create: _.noop,
       getMapping: _.noop,
       putMapping: _.noop,
-      putSettings: _.noop
+      putSettings: _.noop,
+      close: _.noop,
+      open: _.noop
     }
   };
 }
@@ -591,7 +593,10 @@ describe(_.startCase(filename), function () {
   describe('addSettings', function () {
     const fn = lib[this.title];
 
+
     it('runs a `putSettings` if an index exists', function () {
+      client.indices.close.returns(Promise.resolve());
+      client.indices.open.returns(Promise.resolve());
       sandbox.stub(lib, 'existsIndex').returns(bluebird.resolve(true));
       sandbox.stub(lib, 'putSettings');
 

--- a/lib/setup.test.js
+++ b/lib/setup.test.js
@@ -43,6 +43,7 @@ describe(_.startCase(filename), function () {
 
     it('creates a settings object if a mapping includes settings', function () {
       lib(idealOptions);
+      lib.settings = _.omit(lib.settings, ['pages']); // Ignore internal index settings
       expect(lib.settings).to.eql({ 'test-with-settings': {settings: {index: {some_val: true}}}});
     });
   });

--- a/mappings/pages.yml
+++ b/mappings/pages.yml
@@ -1,18 +1,29 @@
+settings:
+  index:
+    analysis:
+      analyzer:
+        stdEnglish:
+          type: standard
+          stopwords: _english_
 general:
-  dynamic: strict
+  dynamic: true
   properties:
     createdAt:
       type: date
     title:
       type: string
       index: analyzed
-      analyzer: simple
+      analyzer: stdEnglish
     titleTruncated:
       type: string
       index: not_analyzed
     authors:
       type: string
-      index: not_analyzed
+      analyzer: standard
+      fields:
+        english:
+          type: string
+          analyzer: stdEnglish
     users:
       type: nested
       properties:
@@ -26,6 +37,9 @@ general:
           type: string
           index: not_analyzed
         provider:
+          type: string
+          index: not_analyzed
+        auth:
           type: string
           index: not_analyzed
         updateTime:

--- a/mappings/pages.yml
+++ b/mappings/pages.yml
@@ -6,7 +6,7 @@ settings:
           type: standard
           stopwords: _english_
 general:
-  dynamic: true
+  dynamic: strict
   properties:
     createdAt:
       type: date


### PR DESCRIPTION
Needed to adjust some things to make analyzers happen in mappings

- Changed the order of the put of settings and mappings
- When adding settings the index needs to be closed and then re-opened
- Fixed some testing that adding settings broke
- Added `auth` to pages mapping for pre-4.0 release
- Analyzed authors names

Makes this happen: https://dl.dropboxusercontent.com/s/wawqh2sgatvazp7/B07470E7-BEA6-42CB-B9AB-B505CBF31509-1768-00008AA556C7BA07.gif?dl=0
