### PR TITLE
Pass through date values to Elastic

### DIFF
--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -17,7 +17,9 @@ var genericTypeParsers = [{
   then: convertOpValuesPropertyToString
 }, {
   when: compare('date'),
-  then: convertOpValuesPropertyToDate
+  then: function (propertyName, ops) {
+    return ops;
+  }
 }, {
   when: compare('object'),
   then: function (propertyName, ops) {
@@ -225,33 +227,6 @@ function convertRedisBatchtoElasticBatch(options) {
   return bulkOps;
 }
 
-/**
- * NOTE: Resolving references for dates is not implemented yet, because probably YAGNI.
- *
- * @param {string} propertyName
- * @param {Array} ops
- */
-function convertOpValuesPropertyToDate(propertyName, ops) {
-  _.each(ops, function (op) {
-    var value = op.value[propertyName];
-
-    if (value !== null && value !== undefined) {
-      if (_.isString(value)) {
-        value = new Date(value);
-      } else if (!_.isDate(value)) {
-        log('warn', 'Bad Date type', propertyName, op);
-        value = null;
-      }
-    }
-
-    // never give null or undefined to ES
-    if (value === null || value === undefined) {
-      delete op.value[propertyName];
-    } else {
-      op.value[propertyName] = value;
-    }
-  });
-}
 
 /**
  * The field types in a mapping have to match exactly, or ES will error.
@@ -328,6 +303,5 @@ module.exports.removeAllReferences = removeAllReferences;
 module.exports.compare = compare;
 // For testing
 module.exports.resolveReferencesForPropertyOfStringType = resolveReferencesForPropertyOfStringType;
-module.exports.convertOpValuesPropertyToDate = convertOpValuesPropertyToDate;
 module.exports.indexWithPrefix = indexWithPrefix;
 module.exports.stripPrefix = stripPrefix;

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -154,8 +154,7 @@ describe(_.startCase(filename), function () {
             { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ],
           mapping = { dynamic: false,
             properties:
-             { primaryHeadline: { type: 'string', index: 'analyzed' } },
-            _timestamp: { enabled: true, store: 'yes' } },
+             { primaryHeadline: { type: 'string', index: 'analyzed' } }},
           result = { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' };
 
         fn(mapping, op).then(function (data) {
@@ -169,8 +168,7 @@ describe(_.startCase(filename), function () {
             value: {feeds: {sitemaps: true, rss: true, newsfeed: true} }} ],
           mapping = { dynamic: false,
             properties:
-             { feeds: { type: 'object', index: 'analyzed' } },
-            _timestamp: { enabled: true, store: 'yes' } },
+             { feeds: { type: 'object', index: 'analyzed' } }},
           result = [ { type: 'put',
             key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
             value: {feeds: {sitemaps: true, rss: true, newsfeed: true} }} ];
@@ -187,25 +185,8 @@ describe(_.startCase(filename), function () {
             { date: '2016-11-20' } } ],
           mapping = { dynamic: false,
             properties:
-             { date: { type: 'date', index: 'analyzed' } },
-            _timestamp: { enabled: true, store: 'yes' } },
-          result = { date: new Date('2016-11-20') };
-
-        fn(mapping, op).then(function (data) {
-          expect(data).to.equal(result);
-        });
-      });
-
-      it('sets value to null if bad date type', function () {
-        let op = [ { type: 'put',
-            key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
-            value:
-            { date: 123 } } ],
-          mapping = { dynamic: false,
-            properties:
-             { date: { type: 'date', index: 'analyzed' } },
-            _timestamp: { enabled: true, store: 'yes' } },
-          result = {};
+             { date: { type: 'date' } }},
+          result = { date: '2016-11-20' };
 
         fn(mapping, op).then(function (data) {
           expect(data).to.equal(result);
@@ -218,8 +199,7 @@ describe(_.startCase(filename), function () {
             value:
             { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ],
           mapping = {properties:
-             { primaryHeadline: { type: 'foo', index: 'analyzed' } },
-          _timestamp: { enabled: true, store: 'yes' } },
+             { primaryHeadline: { type: 'foo', index: 'analyzed' } }},
           result = { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' };
 
         fn(mapping, op).then(function (data) {
@@ -324,43 +304,6 @@ describe(_.startCase(filename), function () {
             value: { content: 'value' }
           }]);
         });
-      });
-    });
-
-    describe('convertOpValuesPropertyToDate', function () {
-      let fn = lib[this.title];
-
-      it('converts a string to a date', function () {
-        let ops = [{ type: 'put',
-          key: 'localhost/components/foo/instances/xyz',
-          value: { date: 'Mon Nov 28 2016' }
-        }];
-
-        fn('date', ops);
-
-        expect(ops[0].value.date).to.be.an.instanceof(Date);
-      });
-
-      it('does not a value that is already a date object', function () {
-        let ops = [{ type: 'put',
-          key: 'localhost/components/foo/instances/xyz',
-          value: { date: new Date() }
-        }];
-
-        fn('date', ops);
-
-        expect(ops[0].value.date).to.be.an.instanceof(Date);
-      });
-
-      it('sdfdsf', function () {
-        let ops = [{ type: 'put',
-          key: 'localhost/components/foo/instances/xyz',
-          value: { date: null }
-        }];
-
-        fn('date', ops);
-
-        expect(ops[0].value).to.deep.equal({});
       });
     });
   });


### PR DESCRIPTION
This PR:

* Removes the `convertOpValuesPropertyToDate` function because:
   - We're passing in a string, converting it to a Date object, and passing it to Elasticsearch. Elasticsearch stores it as a string anyway. 
  - We can't pass in non-string Date objects. We should be able to pass whatever Date obj with whatever format is specified in the mapping. By default, Elasticsearch uses `"strict_date_optional_time||epoch_millis"` for date type mappings.
  - Elasticsearch natively removes properties with undefined values, and just stores null values.
* Removes the _timestamp property from tests because it's been deprecated in 2.4: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/mapping-timestamp-field.html
