### PR TITLE
Don't swallow errors on bulk search

### DIFF
--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -17,6 +17,14 @@ const elastic = require('elasticsearch'),
 // Reference to the ES client
 var client;
 
+/**
+ * convert to human-readable string
+ * @param {any} jsonable
+ * @return {String}
+ */
+function str(jsonable) {
+  return JSON.stringify(jsonable, null, 2);
+}
 
 /**
  * Test whether or not the client is connected
@@ -396,12 +404,9 @@ function batch(ops) {
     body: ops
   }).then(function (resp) {
     if (resp && resp.errors === true) {
-      const message = 'Client.bulk errored on:\n'
-                      + util.inspect(ops, {depth: 10})
-                      + '\n response items:\n'
-                      + util.inspect(resp.items, {depth: 8});
-
-      return bluebird.reject(new Error(message));
+      return bluebird.reject(new Error(
+        `Client.bulk errored on:\n${str(ops)}\n response items:\n${str(resp.items)}`
+      ));
     }
   });
 }

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -396,11 +396,12 @@ function batch(ops) {
     body: ops
   }).then(function (resp) {
     if (resp && resp.errors === true) {
-      let str = ['Client.bulk errored on ' + util.inspect(ops, {
-        depth: 10
-      })];
+      const message = 'Client.bulk errored on:\n'
+                      + util.inspect(ops, {depth: 10})
+                      + '\n response items:\n'
+                      + util.inspect(resp.items, {depth: 8});
 
-      return bluebird.reject(new Error(str));
+      return bluebird.reject(new Error(message));
     }
   });
 }


### PR DESCRIPTION
say what went wrong, as an aid to debugging
Before:

![screen shot 2017-10-03 at 10 39 26 pm](https://user-images.githubusercontent.com/4691093/31157883-12fd063a-a88c-11e7-9d05-3e92de88a6ba.jpg)

After:

![screen shot 2017-10-03 at 10 47 16 pm](https://user-images.githubusercontent.com/4691093/31158035-e601446a-a88c-11e7-9342-c1ccb95526dd.jpg)

It took me about 20 minutes to figure out I was passing an invalid date, but if the error doesn't get swallowed then next time I can see "failed to parse [date]" which will help with this sort of problem.