### PR TITLE
Logging Updates

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.10.0
+    version: 8.9.0
 test:
   override:
     - ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec

--- a/lib/init.js
+++ b/lib/init.js
@@ -5,10 +5,10 @@ const _ = require('lodash'),
   es = require('./services/elastic'),
   path = require('path'),
   files = require('nymag-fs'),
-  log = require('./services/log').setup({file: __filename}),
   acceptedIcons = ['icon.120x120.png', 'icon.180x180', 'icon.192x192.png'],
   pageList = require('./page-list'),
   usersList = require('./users-list');
+var log = require('./services/log').setup({file: __filename});
 
 /**
  * Create the path to the media directory
@@ -78,7 +78,12 @@ function onInit() {
       log('debug', 'sites index populated');
     })
     .catch(err => {
-      throw err;
+      log('fatal', `${err.message}`, {
+        stack: err.stack
+      });
+      // A lot of platform functionality assumes the presence of this
+      // index. We need to exit if there was an error.
+      process.exit(1);
     });
 }
 
@@ -92,3 +97,4 @@ module.exports = onInit;
 module.exports.constructMediaPath = constructMediaPath;
 module.exports.generateSitesIndexOps = generateSitesIndexOps;
 module.exports.setSites = setSites;
+module.exports.setLog = fakeLogger => { log = fakeLogger; };

--- a/lib/init.js
+++ b/lib/init.js
@@ -81,9 +81,7 @@ function onInit() {
       log('fatal', `${err.message}`, {
         stack: err.stack
       });
-      // A lot of platform functionality assumes the presence of this
-      // index. We need to exit if there was an error.
-      process.exit(1);
+      return bluebird.reject(err);
     });
 }
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash'),
   setup = require('./setup'),
+  bluebird = require('bluebird'),
   es = require('./services/elastic'),
   path = require('path'),
   files = require('nymag-fs'),

--- a/lib/init.test.js
+++ b/lib/init.test.js
@@ -40,13 +40,13 @@ describe(_.startCase(filename), function () {
         });
       });
 
-      it('throws an error if the batch function rejects', function () {
+      it('logs an error if the batch function rejects', function () {
         sandbox.stub(lib, 'generateSitesIndexOps').returns([]);
         sandbox.stub(process, 'exit');
         es.batch.returns(bluebird.reject(new Error('test error')));
 
         return lib()
-          .catch(() => {
+          .then(() => {
             sinon.assert.calledWith(logFn, 'fatal');
             sinon.assert.calledOnce(process.exit);
           });

--- a/lib/init.test.js
+++ b/lib/init.test.js
@@ -13,15 +13,17 @@ const bluebird = require('bluebird'),
 
 describe(_.startCase(filename), function () {
   describe(filename, function () {
-    var sandbox,
+    var sandbox, logFn,
       sites =  {
         sites: _.noop
       };
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
+      logFn = sandbox.stub();
 
       sandbox.stub(es);
+      lib.setLog(logFn);
     });
 
     afterEach(function () {
@@ -40,9 +42,14 @@ describe(_.startCase(filename), function () {
 
       it('throws an error if the batch function rejects', function () {
         sandbox.stub(lib, 'generateSitesIndexOps').returns([]);
-        es.batch.returns(bluebird.reject());
+        sandbox.stub(process, 'exit');
+        es.batch.returns(bluebird.reject(new Error('test error')));
 
-        expect(lib()).to.throw;
+        return lib()
+          .catch(() => {
+            sinon.assert.calledWith(logFn, 'fatal');
+            sinon.assert.calledOnce(process.exit);
+          });
       });
     });
 

--- a/lib/init.test.js
+++ b/lib/init.test.js
@@ -46,9 +46,8 @@ describe(_.startCase(filename), function () {
         es.batch.returns(bluebird.reject(new Error('test error')));
 
         return lib()
-          .then(() => {
+          .catch(() => {
             sinon.assert.calledWith(logFn, 'fatal');
-            sinon.assert.calledOnce(process.exit);
           });
       });
     });

--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -3,15 +3,14 @@
 const _ = require('lodash'),
   bluebird = require('bluebird'),
   url = require('url'),
-  log = require('./services/log').setup({file: __filename}),
   filters = require('./services/filters'),
   setup = require('./setup'),
   helpers = require('./services/elastic-helpers'),
   elastic = require('./services/elastic'),
   utils = require('clay-utils'),
   queue = require('./services/queue');
-
-var PAGES_INDEX;
+var log = require('./services/log').setup({file: __filename}),
+ PAGES_INDEX;
 
 function setPagesIndex() {
   PAGES_INDEX = helpers.indexWithPrefix('pages');
@@ -263,7 +262,7 @@ function updatePageEntry(pageUri, updateObj) {
   if (!_.isObject(updateObj)) {
     err = new Error('An object with properties to update is required to update the page list');
   } else if (!pageUri || !_.isString(pageUri)) {
-    err = new Error(`Expected pageUri {String}, but got: ${pageUri}`);
+    err = new TypeError(`Expected pageUri {String}, but got: ${pageUri}`);
   }
 
   if (err) {
@@ -372,3 +371,4 @@ module.exports.setPagesIndex = setPagesIndex;
 module.exports.setSites = setSites;
 module.exports.parseUpdateUrl = parseUpdateUrl;
 module.exports.constructFindQuery = constructFindQuery;
+module.exports.setLog = fakeLogger => { log = fakeLogger; };

--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -66,10 +66,6 @@ function pageUriFromKey(key) {
  * @return {Object}
  */
 function findSite(key) {
-  // if (!_.get(setup, 'options.sites', null)) {
-  //   throw new Error('Womp');
-  // }
-
   var site = setup.options.sites.getSiteFromPrefix(key),
     parsedUrl;
 
@@ -179,7 +175,10 @@ function updateExistingPageData(ops) {
  */
 function updatePageData(pageUri, data) {
   if (!data) {
-    throw new Error('Updating a page requires a data object');
+    let err = new Error('Updating a page requires a data object');
+
+    log('error', err.message, { stack: err.stack, dataArg: data });
+    return bluebird.reject(err);
   }
 
   return elastic.update(PAGES_INDEX, 'general', pageUri, data, true)
@@ -259,10 +258,17 @@ function truncateTitle(title) {
  * @return {Promise}
  */
 function updatePageEntry(pageUri, updateObj) {
+  var err;
+
   if (!_.isObject(updateObj)) {
-    throw new Error('An object with properties to update is required to update the page list');
+    err = new Error('An object with properties to update is required to update the page list');
   } else if (!pageUri || !_.isString(pageUri)) {
-    throw new Error('Expected pageUri {String}, but got: ', pageUri);
+    err = new Error(`Expected pageUri {String}, but got: ${pageUri}`);
+  }
+
+  if (err) {
+    log('error', err.message, { stack: err.stack, pageUri });
+    return bluebird.reject(err);
   }
 
   // Let's truncate the title string to only be 75 characters + '...'
@@ -323,7 +329,10 @@ function updatePageListEntry(value) {
  */
 function findPageAndUpdate(reqObj, res) {
   if (!reqObj.url) {
-    throw new Error('Cannot find page without a url');
+    let err = new Error('Cannot find page without a url');
+
+    log('error', err.message, { stack: err.stack });
+    return bluebird.reject(err);
   }
 
   return queue.add(function () {
@@ -333,7 +342,6 @@ function findPageAndUpdate(reqObj, res) {
     res.status(200);
     res.json({ status: 'Success' });
   }).catch(function (err) {
-    // TODO: Improve this handling. Make more generic.
     res.status(400);
     res.json(err);
   });

--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -341,6 +341,7 @@ function findPageAndUpdate(reqObj, res) {
     res.status(200);
     res.json({ status: 'Success' });
   }).catch(function (err) {
+    log('error', err.message, { stack: err.stack });
     res.status(400);
     res.json(err);
   });

--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -10,7 +10,7 @@ const _ = require('lodash'),
   utils = require('clay-utils'),
   queue = require('./services/queue');
 var log = require('./services/log').setup({file: __filename}),
- PAGES_INDEX;
+  PAGES_INDEX;
 
 function setPagesIndex() {
   PAGES_INDEX = helpers.indexWithPrefix('pages');

--- a/lib/page-list.test.js
+++ b/lib/page-list.test.js
@@ -410,7 +410,7 @@ describe(_.startCase(filename), function () {
       fn(undefined, {prop: 'value'}).catch(assertLoggedError(errMsg));
     });
 
-    it('throws an error if a page uri is not a string', function () {
+    it('logs an error if a page uri is not a string', function () {
       const errMsg = 'Expected pageUri {String}, but got: 2313';
 
       fn(2313, {prop: 'value'}).catch(assertLoggedError(errMsg));

--- a/lib/page-list.test.js
+++ b/lib/page-list.test.js
@@ -48,7 +48,7 @@ describe(_.startCase(filename), function () {
     return function (err) {
       sinon.assert.calledWith(logFn, 'error', errMsg);
       expect(err.message).to.equal(errMsg);
-    }
+    };
   }
 
   beforeEach(function () {
@@ -405,13 +405,13 @@ describe(_.startCase(filename), function () {
     });
 
     it('logs an error if no page uri is passed in', function () {
-      const errMsg = `Expected pageUri {String}, but got: undefined`;
+      const errMsg = 'Expected pageUri {String}, but got: undefined';
 
       fn(undefined, {prop: 'value'}).catch(assertLoggedError(errMsg));
     });
 
     it('throws an error if a page uri is not a string', function () {
-      const errMsg = `Expected pageUri {String}, but got: 2313`;
+      const errMsg = 'Expected pageUri {String}, but got: 2313';
 
       fn(2313, {prop: 'value'}).catch(assertLoggedError(errMsg));
     });

--- a/lib/page-list.test.js
+++ b/lib/page-list.test.js
@@ -38,19 +38,28 @@ const _ = require('lodash'),
   }];
 
 describe(_.startCase(filename), function () {
-  let sandbox,
+  let sandbox, logFn,
     sites = {
       getSiteFromPrefix: _.noop,
       getSite: _.noop
     };
 
+  function assertLoggedError(errMsg) {
+    return function (err) {
+      sinon.assert.calledWith(logFn, 'error', errMsg);
+      expect(err.message).to.equal(errMsg);
+    }
+  }
+
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    logFn = sandbox.stub();
     sandbox.stub(search);
     sandbox.stub(queue);
     sandbox.stub(responses);
     sandbox.stub(helpers);
     sandbox.stub(sites);
+    lib.setLog(logFn);
   });
 
   afterEach(function () {
@@ -127,12 +136,10 @@ describe(_.startCase(filename), function () {
   describe('updatePageData', function () {
     const fn = lib[this.title];
 
-    it('throws an error when no data is supplied', function () {
-      var result = function () {
-        fn();
-      };
+    it('logs an error when no data is supplied', function () {
+      const errMsg = 'Updating a page requires a data object';
 
-      expect(result).to.throw(Error);
+      return fn().catch(assertLoggedError(errMsg));
     });
 
     it('catches when the update fails', function () {
@@ -391,22 +398,22 @@ describe(_.startCase(filename), function () {
   describe('updatePageEntry', function () {
     const fn = lib[this.title];
 
-    it('throws an error if an object is not passed in', function () {
-      const objError = () => fn('arg');
+    it('logs an error if an object is not passed in', function () {
+      const errMsg = 'An object with properties to update is required to update the page list';
 
-      expect(objError).to.throw(Error);
+      fn('arg').catch(assertLoggedError(errMsg));
     });
 
-    it('throws an error if no page uri is passed in', function () {
-      const uriError = () => fn(undefined, {prop: 'value'});
+    it('logs an error if no page uri is passed in', function () {
+      const errMsg = `Expected pageUri {String}, but got: undefined`;
 
-      expect(uriError).to.throw(Error);
+      fn(undefined, {prop: 'value'}).catch(assertLoggedError(errMsg));
     });
 
     it('throws an error if a page uri is not a string', function () {
-      const uriError = () => fn(2313, {prop: 'value'});
+      const errMsg = `Expected pageUri {String}, but got: 2313`;
 
-      expect(uriError).to.throw(Error);
+      fn(2313, {prop: 'value'}).catch(assertLoggedError(errMsg));
     });
 
     it('truncates the `title` property', function () {
@@ -459,12 +466,10 @@ describe(_.startCase(filename), function () {
   describe('findPageAndUpdate', function () {
     const fn = lib[this.title];
 
-    it('throws an error if there is no `url` property', function () {
-      var result = function () {
-        fn({});
-      };
+    it('logs an error if there is no `url` property', function () {
+      const errMsg = 'Cannot find page without a url';
 
-      expect(result).to.throw(Error);
+      return fn({}).catch(assertLoggedError(errMsg));
     });
 
     it('adds an elastic update to the queue', function () {

--- a/lib/routes/_search.js
+++ b/lib/routes/_search.js
@@ -3,7 +3,8 @@
 const _ = require('lodash'),
   elastic = require('../services/elastic'),
   helpers = require('../services/elastic-helpers'),
-  responses = require('../services/responses');
+  responses = require('../services/responses'),
+  log = require('../services/log').setup({ file: __filename });
 
 /**
  * Add the prefix to any index specified
@@ -13,7 +14,10 @@ const _ = require('lodash'),
  */
 function decorateWithPrefix(queryObj) {
   if (!queryObj.index) {
-    throw new Error('An index property is required to search');
+    let err = new Error('An index property is required to search');
+
+    log('error', err.message, { stack: err.stack });
+    return bluebird.reject(err);
   }
 
   queryObj.index = helpers.indexWithPrefix(queryObj.index);

--- a/lib/routes/_update.js
+++ b/lib/routes/_update.js
@@ -2,7 +2,8 @@
 
 const elastic = require('../services/elastic'),
   helpers = require('../services/elastic-helpers'),
-  responses = require('../services/responses');
+  responses = require('../services/responses'),
+  log = require('../services/log').setup({ file: __filename });
 
 /**
  * Validate update request for existence of index, type, id, and body
@@ -13,7 +14,10 @@ const elastic = require('../services/elastic'),
  */
 function validateUpdateRequest(updateBody) {
   if (!updateBody.index || !updateBody.type || !updateBody.id || !updateBody.body) {
-    throw new Error('An index, type, id, and body property are all required to update');
+    let err = new Error('An index, type, id, and body property are all required to update');
+
+    log('error', err.message, { stack: err.stack });
+    return bluebird.reject(err);
   }
 
   updateBody.index = helpers.indexWithPrefix(updateBody.index);

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -4,8 +4,8 @@
 const _ = require('lodash'),
   bluebird = require('bluebird'),
   refProp = '_ref',
-  log = require('./log').setup({file: __filename}),
   setup = require('../setup');
+var log = require('./log').setup({file: __filename});
 
 /**
  * Used to test Elasticsearch data types
@@ -305,3 +305,4 @@ module.exports.compare = compare;
 module.exports.resolveReferencesForPropertyOfStringType = resolveReferencesForPropertyOfStringType;
 module.exports.indexWithPrefix = indexWithPrefix;
 module.exports.stripPrefix = stripPrefix;
+module.exports.setLog = fakeLogger => { log = fakeLogger; };

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -5,27 +5,21 @@ const _ = require('lodash'),
   bluebird = require('bluebird'),
   refProp = '_ref',
   setup = require('../setup');
-var log = require('./log').setup({file: __filename});
-
-/**
- * Used to test Elasticsearch data types
- *
- * @type {Array}
- */
-var genericTypeParsers = [{
-  when: compare('string'),
-  then: convertOpValuesPropertyToString
-}, {
-  when: compare('date'),
-  then: function (propertyName, ops) {
-    return ops;
-  }
-}, {
-  when: compare('object'),
-  then: function (propertyName, ops) {
-    return ops;
-  }
-}];
+var log = require('./log').setup({file: __filename}),
+  genericTypeParsers = [{ // used to test Elastic data types
+    when: compare('string'),
+    then: convertOpValuesPropertyToString
+  }, {
+    when: compare('date'),
+    then: function (propertyName, ops) {
+      return ops;
+    }
+  }, {
+    when: compare('object'),
+    then: function (propertyName, ops) {
+      return ops;
+    }
+  }];
 
 // Required for `_.listDeepObjects`
 _.mixin(require('lodash-ny-util'));

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -210,7 +210,7 @@ function convertRedisBatchtoElasticBatch(options) {
         case 'delete':
           break;
         default:
-          throw new Error(`${action} is not supported`);
+          log('error', `Action ${action} is not supported`);
       }
 
       // Push the operation in before the request body

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -10,12 +10,15 @@ const sinon = require('sinon'),
 
 describe(_.startCase(filename), function () {
   describe(filename, function () {
-    var sandbox, db = { get: _.noop, put: _.noop };
+    var sandbox, logFn,
+      db = { get: _.noop, put: _.noop };
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
+      logFn = sandbox.stub();
       sandbox.stub(db, 'get');
       sandbox.stub(db, 'put');
+      lib.setLog(logFn);
     });
 
     afterEach(function () {
@@ -73,10 +76,11 @@ describe(_.startCase(filename), function () {
         expect(fn({index: 'index', type: 'type', ops: ops, action: 'create'})).to.deep.equal([{ create: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
       });
 
-      it('throws on unsupported action', function () {
+      it('logs on unsupported action', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn.bind(null, {index: 'index', type: 'type', ops: ops, action: 'someUnsupportedAction'})).to.throw('someUnsupportedAction is not supported');
+        fn({index: 'index', type: 'type', ops: ops, action: 'someUnsupportedAction'});
+        sinon.assert.calledWith(logFn, 'error', 'Action someUnsupportedAction is not supported');
       });
     });
 

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -159,10 +159,12 @@ describe(_.startCase(filename), function () {
           mapping = { dynamic: false,
             properties:
              { primaryHeadline: { type: 'string', index: 'analyzed' } }},
-          result = { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' };
+          result = [ { type: 'put',
+    key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
+    value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
 
         fn(mapping, op).then(function (data) {
-          expect(data).to.equal(result);
+          expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
 
@@ -178,7 +180,7 @@ describe(_.startCase(filename), function () {
             value: {feeds: {sitemaps: true, rss: true, newsfeed: true} }} ];
 
         fn(mapping, op).then(function (data) {
-          expect(data).to.equal(result);
+          expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
 
@@ -190,10 +192,12 @@ describe(_.startCase(filename), function () {
           mapping = { dynamic: false,
             properties:
              { date: { type: 'date' } }},
-          result = { date: '2016-11-20' };
+          result = [ { type: 'put',
+    key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
+    value: { date: '2016-11-20' } } ];
 
         fn(mapping, op).then(function (data) {
-          expect(data).to.equal(result);
+          expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
 
@@ -204,10 +208,12 @@ describe(_.startCase(filename), function () {
             { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ],
           mapping = {properties:
              { primaryHeadline: { type: 'foo', index: 'analyzed' } }},
-          result = { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' };
+          result = [ { type: 'put',
+    key: 'localhost/sitename/components/foo/instances/xyz',
+    value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
 
         fn(mapping, op).then(function (data) {
-          expect(data).to.equal(result);
+          expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
     });

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -160,8 +160,8 @@ describe(_.startCase(filename), function () {
             properties:
              { primaryHeadline: { type: 'string', index: 'analyzed' } }},
           result = [ { type: 'put',
-    key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
-    value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
+            key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
+            value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
 
         fn(mapping, op).then(function (data) {
           expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
@@ -193,8 +193,8 @@ describe(_.startCase(filename), function () {
             properties:
              { date: { type: 'date' } }},
           result = [ { type: 'put',
-    key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
-    value: { date: '2016-11-20' } } ];
+            key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
+            value: { date: '2016-11-20' } } ];
 
         fn(mapping, op).then(function (data) {
           expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
@@ -209,8 +209,8 @@ describe(_.startCase(filename), function () {
           mapping = {properties:
              { primaryHeadline: { type: 'foo', index: 'analyzed' } }},
           result = [ { type: 'put',
-    key: 'localhost/sitename/components/foo/instances/xyz',
-    value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
+            key: 'localhost/sitename/components/foo/instances/xyz',
+            value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
 
         fn(mapping, op).then(function (data) {
           expect(JSON.stringify(data)).to.equal(JSON.stringify(result));

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -4,7 +4,6 @@ const elastic = require('elasticsearch'),
   helpers = require('./elastic-helpers'),
   bluebird = require('bluebird'),
   _ = require('lodash'),
-  util = require('util'),
   endpoint = process.env.ELASTIC_HOST || '',
   serverConfig = {
     host: endpoint,
@@ -16,21 +15,11 @@ var log = require('./log').setup({file: __filename}),
   client; // Reference to the ES client
 
 /**
- * [logError description]
- * @param  {[type]} err [description]
- * @return {[type]}     [description]
+ * Log the error with the stacktrace
+ * @param  {Error} err
  */
 function logError(err) {
   log('error', err.message, { stack: err.stack });
-}
-
-/**
- * convert to human-readable string
- * @param {any} jsonable
- * @return {String}
- */
-function str(jsonable) {
-  return JSON.stringify(jsonable, null, 2);
 }
 
 /**
@@ -322,7 +311,7 @@ function convertRedisBatchtoElasticBatch(index, type, ops) {
       log('error', 'op.value cannot be a string', {
         stack: err.stack,
         op
-      })
+      });
     } else if (op.type === 'put') {
       let indexOp = {
         _index: index,

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -423,13 +423,14 @@ function batch(ops) {
  * Create the ES Client or an empty object
  *
  * @param {Object} overrideClient
+ * @returns {Promise}
  */
 function setup(overrideClient) {
   if (!module.exports.endpoint && !overrideClient) {
     let err = new Error('No Elastic endpoint or client override');
 
     log('fatal', `${err.message}`, { stack: err.stack });
-    process.exit(1); // We can't do anything without an endpoint or override
+    return bluebird.reject(err);
   }
 
   // Set the exported client

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -5,7 +5,6 @@ const elastic = require('elasticsearch'),
   bluebird = require('bluebird'),
   _ = require('lodash'),
   util = require('util'),
-  log = require('./log').setup({file: __filename}),
   endpoint = process.env.ELASTIC_HOST || '',
   serverConfig = {
     host: endpoint,
@@ -13,9 +12,17 @@ const elastic = require('elasticsearch'),
     apiVersion: '2.4',
     defer: () => bluebird.defer()
   };
+var log = require('./log').setup({file: __filename}),
+  client; // Reference to the ES client
 
-// Reference to the ES client
-var client;
+/**
+ * [logError description]
+ * @param  {[type]} err [description]
+ * @return {[type]}     [description]
+ */
+function logError(err) {
+  log('error', err.message, { stack: err.stack });
+}
 
 /**
  * convert to human-readable string
@@ -89,7 +96,7 @@ function existsDocument(index, type, id) {
   if (!id) {
     let err = new Error('Cannot check if document exists without an id');
 
-    log('error', err.message, { stack: err.stack });
+    logError(err);
     return bluebird.reject(err);
   }
 
@@ -432,6 +439,7 @@ function setup(overrideClient) {
   if (!module.exports.endpoint && !overrideClient) {
     let err = new Error('No Elastic endpoint or client override');
 
+
     log('fatal', `${err.message}`, { stack: err.stack });
     process.exit(1); // We can't do anything without an endpoint or override
   }
@@ -484,7 +492,7 @@ function getDocument(index, type, id) {
   if (!id) {
     let err = new Error('Cannot get a document without the id');
 
-    log('error', err.message, { stack: err.stack });
+    logError(err);
     return bluebird.reject(err);
   }
 
@@ -510,7 +518,7 @@ function update(index, type, id, data, refresh = false, upsert = false) { // esl
   if (!data) {
     let err = new Error('Updating an Elastic document requires a data object');
 
-    log('error', err.message, { stack: err.stack });
+    logError(err);
     return bluebird.reject(err);
   }
 
@@ -554,3 +562,4 @@ module.exports.validateIndices = validateIndices;
 module.exports.getInstance = getInstance;
 // Exported for testing
 module.exports.createIndexName = createIndexName;
+module.exports.setLog = fakeLogger => { log = fakeLogger; };

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -87,7 +87,10 @@ function existsIndex(index) {
  */
 function existsDocument(index, type, id) {
   if (!id) {
-    throw new Error('Cannot check if document exists without an id');
+    let err = new Error('Cannot check if document exists without an id');
+
+    log('error', err.message, { stack: err.stack });
+    return bluebird.reject(err);
   }
 
   return client.exists({
@@ -307,7 +310,12 @@ function convertRedisBatchtoElasticBatch(index, type, ops) {
 
   _.each(ops, function (op) {
     if (_.isString(op.value)) {
-      throw new TypeError('op.value cannot be string: ' + JSON.stringify(op));
+      let err = new TypeError('op.value cannot be string');
+
+      log('error', 'op.value cannot be a string', {
+        stack: err.stack,
+        op
+      })
     } else if (op.type === 'put') {
       let indexOp = {
         _index: index,
@@ -404,9 +412,13 @@ function batch(ops) {
     body: ops
   }).then(function (resp) {
     if (resp && resp.errors === true) {
-      return bluebird.reject(new Error(
-        `Client.bulk errored on:\n${str(ops)}\n response items:\n${str(resp.items)}`
-      ));
+      let err = new Error('Client.bulk errored on batch operation');
+
+      log('error', err.message, {
+        ops,
+        items: resp.items
+      });
+      return bluebird.reject(err);
     }
   });
 }
@@ -418,7 +430,10 @@ function batch(ops) {
  */
 function setup(overrideClient) {
   if (!module.exports.endpoint && !overrideClient) {
-    throw new Error('No Elastic endpoint or client override');
+    let err = new Error('No Elastic endpoint or client override');
+
+    log('fatal', `${err.message}`, { stack: err.stack });
+    process.exit(1); // We can't do anything without an endpoint or override
   }
 
   // Set the exported client
@@ -467,7 +482,10 @@ function validateIndices(mappings, settings, prefix) {
  */
 function getDocument(index, type, id) {
   if (!id) {
-    throw new Error('Cannot get a document without the id');
+    let err = new Error('Cannot get a document without the id');
+
+    log('error', err.message, { stack: err.stack });
+    return bluebird.reject(err);
   }
 
   return client.get({
@@ -490,7 +508,10 @@ function getDocument(index, type, id) {
  */
 function update(index, type, id, data, refresh = false, upsert = false) { // eslint-disable-line max-params
   if (!data) {
-    throw new Error('Updating an Elastic document requires a data object');
+    let err = new Error('Updating an Elastic document requires a data object');
+
+    log('error', err.message, { stack: err.stack });
+    return bluebird.reject(err);
   }
 
   return client.update({

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -428,7 +428,6 @@ function setup(overrideClient) {
   if (!module.exports.endpoint && !overrideClient) {
     let err = new Error('No Elastic endpoint or client override');
 
-
     log('fatal', `${err.message}`, { stack: err.stack });
     process.exit(1); // We can't do anything without an endpoint or override
   }

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -40,14 +40,16 @@ function createFakeClientClass() {
 }
 
 describe(_.startCase(filename), function () {
-  var sandbox,
+  var sandbox, logFn,
     client = createFakeClientClass();
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    logFn = sinon.stub();
     sandbox.stub(client);
     sandbox.stub(client.indices);
     lib.setup(client);
+    lib.setLog(logFn);
   });
 
   afterEach(function () {
@@ -57,11 +59,10 @@ describe(_.startCase(filename), function () {
   // setup
   describe('setup', function () {
     it('creates an Elastic client if an endpoint is defined and no override is passed in', function () {
-      var result = function () {
-        lib.setup();
-      };
-
-      expect(result).to.throw(Error);
+      sinon.stub(process, 'exit');
+      lib.setup();
+      sinon.assert.calledOnce(process.exit);
+      sinon.assert.calledWith(logFn, 'fatal');
     });
 
     it('returns an instance with fake client if one is passed in', function () {
@@ -301,12 +302,14 @@ describe(_.startCase(filename), function () {
   describe('existsDocument', function () {
     var fn = lib[this.title];
 
-    it('throws an error if no id is provided', function () {
-      var result = function () {
-        fn('pages', 'general');
-      };
+    it('rejects if no id is provided', function () {
+      const errMsg = 'Cannot check if document exists without an id';
 
-      expect(result).to.throw(Error);
+      return fn('pages', 'general')
+        .catch(err => {
+          sinon.assert.calledWith(logFn, 'error', errMsg);
+          expect(err.message).to.equal(errMsg);
+        });
     });
 
     it('calls the exists method provided by the ES client', function () {
@@ -321,12 +324,14 @@ describe(_.startCase(filename), function () {
   describe('getDocument', function () {
     var fn = lib[this.title];
 
-    it('throws an error if no id is provided', function () {
-      var result = function () {
-        fn('pages', 'general');
-      };
+    it('rejects if no id is provided', function () {
+      const errMsg = 'Cannot get a document without the id';
 
-      expect(result).to.throw(Error);
+      return fn('pages', 'general')
+        .catch(err => {
+          sinon.assert.calledWith(logFn, 'error', errMsg);
+          expect(err.message).to.equal(errMsg);
+        });
     });
 
     it('calls the exists method provided by the ES client', function () {
@@ -341,12 +346,14 @@ describe(_.startCase(filename), function () {
   describe('update', function () {
     var fn = lib[this.title];
 
-    it('throws an error if no data is provided', function () {
-      var result = function () {
-        fn('pages', 'general', 'site/pages/foo');
-      };
+    it('rejects if no data is provided', function () {
+      const errMsg = 'Updating an Elastic document requires a data object';
 
-      expect(result).to.throw(Error);
+      return fn('pages', 'general', 'site/pages/foo')
+        .catch(err => {
+          sinon.assert.calledWith(logFn, 'error', errMsg);
+          expect(err.message).to.equal(errMsg);
+        });
     });
 
     it('calls the update method provided by the ES client', function () {
@@ -517,17 +524,16 @@ describe(_.startCase(filename), function () {
     });
   });
 
-  // convertRedisBatchtoElasticBatch
   describe('convertRedisBatchtoElasticBatch', function () {
     var fn = lib[this.title];
 
-    it('throws error if op.value is a string', function () {
-      var ops = [{ value: 'value' }],
-        result = function () {
-          fn('index', 'type', ops);
-        };
+    it('logs an error if op.value is a string', function () {
+      const ops = [{ value: 'value' }],
+        errMsg = 'op.value cannot be a string';
 
-      expect(result).to.throw(TypeError);
+      fn('index', 'type', ops);
+      sinon.assert.calledWith(logFn, 'error', errMsg);
+      expect(logFn.args[0][2].op).to.eql(ops[0]);
     });
 
     it('returns an array of ops if type property equals "put"', function () {

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -59,7 +59,7 @@ describe(_.startCase(filename), function () {
   // setup
   describe('setup', function () {
     it('creates an Elastic client if an endpoint is defined and no override is passed in', function () {
-      sinon.stub(process, 'exit');
+      sandbox.stub(process, 'exit');
       lib.setup();
       sinon.assert.calledOnce(process.exit);
       sinon.assert.calledWith(logFn, 'fatal');

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -59,10 +59,10 @@ describe(_.startCase(filename), function () {
   // setup
   describe('setup', function () {
     it('creates an Elastic client if an endpoint is defined and no override is passed in', function () {
-      sandbox.stub(process, 'exit');
-      lib.setup();
-      sinon.assert.calledOnce(process.exit);
-      sinon.assert.calledWith(logFn, 'fatal');
+      return lib.setup()
+        .catch(() => {
+          sinon.assert.calledWith(logFn, 'fatal');
+        });
     });
 
     it('returns an instance with fake client if one is passed in', function () {

--- a/lib/services/log.js
+++ b/lib/services/log.js
@@ -8,6 +8,10 @@ var amphoraSearchLogInstance;
  * Initialize the logger
  */
 function init() {
+  if (amphoraSearchLogInstance) {
+    return;
+  }
+
   // Initialize the logger
   clayLog.init({
     name: 'amphora-search',
@@ -27,12 +31,21 @@ function init() {
  * @param  {Object} meta
  * @return {Function}
  */
-function setup(meta) {
+function setup(meta = {}) {
   return clayLog.meta(meta, amphoraSearchLogInstance);
 }
 
+/**
+ * Set the logger instance
+ * @param {Object|Function} replacement
+ */
+function setLogger(replacement) {
+  amphoraSearchLogInstance = replacement;
+}
+
 // Setup on first require
-amphoraSearchLogInstance ? undefined : init();
+init();
 
 module.exports.init = init;
 module.exports.setup = setup;
+module.exports.setLogger = setLogger;

--- a/lib/services/log.test.js
+++ b/lib/services/log.test.js
@@ -2,7 +2,6 @@
 const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
-  expect = require('chai').expect,
   sinon = require('sinon'),
   clayLog = require('clay-log');
 

--- a/lib/services/log.test.js
+++ b/lib/services/log.test.js
@@ -4,33 +4,29 @@ const _ = require('lodash'),
   lib = require('./' + filename),
   expect = require('chai').expect,
   sinon = require('sinon'),
-  bluebird = require('bluebird');
-
-function promise() {
-  return new bluebird(function (resolve) {
-    resolve('called');
-  });
-}
+  clayLog = require('clay-log');
 
 describe(_.startCase(filename), function () {
-  let sandbox;
+  let sandbox, fakeLogger;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    fakeLogger = sandbox.stub();
+    lib.setLogger(fakeLogger);
   });
 
   afterEach(function () {
     sandbox.restore();
+    lib.setLogger(undefined);
   });
 
-  describe('add', function () {
+  describe('init', function () {
     const fn = lib[this.title];
 
-    it('works', function () {
-      return fn(promise)
-        .then(function (resp) {
-          expect(resp).to.equal('called');
-        });
+    it('does not call init once it has already been instantiated', function () {
+      sandbox.stub(clayLog, 'init');
+      fn();
+      sinon.assert.notCalled(clayLog.init);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "amphora-search",
-  "version": "1.0.2-test-query-times",
+  "version": "3.1.3",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -10,14 +11,18 @@
       "dev": true
     },
     "accepts": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -25,6 +30,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -40,22 +48,33 @@
       "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -64,9 +83,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -82,7 +101,10 @@
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -93,7 +115,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -149,10 +174,15 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -164,28 +194,50 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
-      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4="
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
     },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -193,16 +245,45 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "build": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
+      "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
+      "dev": true,
+      "requires": {
+        "cssmin": "0.3.2",
+        "jsmin": "1.0.1",
+        "jxLoader": "0.1.1",
+        "moo-server": "1.3.0",
+        "promised-io": "0.3.5",
+        "timespan": "2.3.0",
+        "uglify-js": "1.3.5",
+        "walker": "1.0.7",
+        "winston": "2.4.0",
+        "wrench": "1.3.9"
+      },
+      "dependencies": {
+        "uglify-js": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+          "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+          "dev": true
+        }
+      }
+    },
     "bytes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -228,33 +309,78 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
+    "clay-log": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clay-log/-/clay-log-1.2.1.tgz",
+      "integrity": "sha1-XJnLr8dc2ECL1CzpRuF4al/ZOkk=",
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "pino": "4.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        }
+      }
+    },
     "clay-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clay-utils/-/clay-utils-1.1.1.tgz",
-      "integrity": "sha1-QBS3OEIGJJ3Qyj5UReFfkKbzskM=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/clay-utils/-/clay-utils-1.3.0.tgz",
+      "integrity": "sha1-rqOl/cVklvXpa41AozBE1gmIga8=",
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "nymag-fs": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.0.tgz"
+      },
       "dependencies": {
         "chai": {
           "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "requires": {
+            "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+            "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+            "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+          },
           "dependencies": {
             "assertion-error": {
               "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
@@ -263,6 +389,9 @@
             "deep-eql": {
               "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+              "requires": {
+                "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+              },
               "dependencies": {
                 "type-detect": {
                   "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
@@ -279,6 +408,13 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -291,6 +427,9 @@
             "has-ansi": {
               "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -301,6 +440,9 @@
             "strip-ansi": {
               "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -315,133 +457,227 @@
           }
         },
         "coveralls": {
-          "version": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.0.tgz",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.0.tgz",
           "integrity": "sha1-35M4dujG9HjvsE9NOrcNyWt+Wo4=",
+          "requires": {
+            "js-yaml": "3.6.1",
+            "lcov-parse": "0.0.10",
+            "log-driver": "1.2.5",
+            "minimist": "1.2.0",
+            "request": "2.79.0"
+          },
           "dependencies": {
             "js-yaml": {
-              "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
               "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+              "requires": {
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
+              },
               "dependencies": {
                 "argparse": {
-                  "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  },
                   "dependencies": {
                     "sprintf-js": {
-                      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                     }
                   }
                 },
                 "esprima": {
-                  "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                  "version": "2.7.3",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
                   "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
                 }
               }
             },
             "lcov-parse": {
-              "version": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
               "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
             },
             "log-driver": {
-              "version": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
               "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
             },
             "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             },
             "request": {
-              "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+              "version": "2.79.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
               "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.0",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "qs": "6.3.2",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.4.3",
+                "uuid": "3.0.1"
+              },
               "dependencies": {
                 "aws-sign2": {
-                  "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
                   "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
                 },
                 "aws4": {
-                  "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                  "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
                   "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
                 },
                 "caseless": {
-                  "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
                   "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
                 },
                 "combined-stream": {
-                  "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
                   "dependencies": {
                     "delayed-stream": {
-                      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                     }
                   }
                 },
                 "extend": {
-                  "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
                   "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
                 },
                 "forever-agent": {
-                  "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                   "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
                 },
                 "form-data": {
-                  "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                  "version": "2.1.4",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
                   "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  },
                   "dependencies": {
                     "asynckit": {
-                      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                      "version": "0.4.0",
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
                       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                     }
                   }
                 },
                 "har-validator": {
-                  "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                  "requires": {
+                    "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "commander": "2.9.0",
+                    "is-my-json-valid": "2.16.0",
+                    "pinkie-promise": "2.0.1"
+                  },
                   "dependencies": {
                     "commander": {
-                      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "version": "2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
                       "dependencies": {
                         "graceful-readlink": {
-                          "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                           "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
                         }
                       }
                     },
                     "is-my-json-valid": {
-                      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+                      "version": "2.16.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
                       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.1",
+                        "xtend": "4.0.1"
+                      },
                       "dependencies": {
                         "generate-function": {
-                          "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                           "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
                         },
                         "generate-object-property": {
-                          "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
                           "dependencies": {
                             "is-property": {
-                              "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                               "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
                             }
                           }
                         },
                         "jsonpointer": {
-                          "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
                           "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
                         },
                         "xtend": {
-                          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                         }
                       }
                     },
                     "pinkie-promise": {
-                      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
                       "dependencies": {
                         "pinkie": {
-                          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
                         }
                       }
@@ -449,99 +685,176 @@
                   }
                 },
                 "hawk": {
-                  "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
                   "dependencies": {
                     "boom": {
-                      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     },
                     "cryptiles": {
-                      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
                     },
                     "hoek": {
-                      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
                     },
                     "sntp": {
-                      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     }
                   }
                 },
                 "http-signature": {
-                  "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                   "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.0"
+                  },
                   "dependencies": {
                     "assert-plus": {
-                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
                     },
                     "jsprim": {
-                      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "version": "1.4.0",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
                       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
                       "dependencies": {
                         "assert-plus": {
-                          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                         },
                         "extsprintf": {
-                          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                           "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
                         },
                         "json-schema": {
-                          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                         },
                         "verror": {
-                          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+                          "version": "1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
                         }
                       }
                     },
                     "sshpk": {
-                      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                      "version": "1.13.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
                       "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                      },
                       "dependencies": {
                         "asn1": {
-                          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                           "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                         },
                         "assert-plus": {
-                          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                         },
                         "bcrypt-pbkdf": {
-                          "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.5"
+                          }
                         },
                         "dashdash": {
-                          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
+                          "version": "1.14.1",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "ecc-jsbn": {
-                          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.1"
+                          }
                         },
                         "getpass": {
-                          "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
+                          "version": "0.1.7",
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "jodid25519": {
-                          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.1"
+                          }
                         },
                         "jsbn": {
-                          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
                           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                           "optional": true
                         },
                         "tweetnacl": {
-                          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                          "version": "0.14.5",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                           "optional": true
                         }
@@ -550,55 +863,73 @@
                   }
                 },
                 "is-typedarray": {
-                  "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
                   "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
                 },
                 "isstream": {
-                  "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                   "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
                 },
                 "json-stringify-safe": {
-                  "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                   "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
                 },
                 "mime-types": {
-                  "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "version": "2.1.15",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
                   "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  },
                   "dependencies": {
                     "mime-db": {
-                      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "version": "1.27.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
                       "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
                     }
                   }
                 },
                 "oauth-sign": {
-                  "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "version": "0.8.2",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
                   "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
                 },
                 "qs": {
-                  "version": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+                  "version": "6.3.2",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
                   "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
                 },
                 "stringstream": {
-                  "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                   "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
                 },
                 "tough-cookie": {
-                  "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "version": "2.3.2",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                   "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
                   "dependencies": {
                     "punycode": {
-                      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                      "version": "1.4.1",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                     }
                   }
                 },
                 "tunnel-agent": {
-                  "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                  "version": "0.4.3",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
                   "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
                 },
                 "uuid": {
-                  "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
                   "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
                 }
               }
@@ -608,10 +939,52 @@
         "eslint": {
           "version": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
           "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+          "requires": {
+            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+            "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+            "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+            "espree": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+            "esquery": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+            "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+            "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+            "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+            "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+            "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+            "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+            "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+          },
           "dependencies": {
             "babel-code-frame": {
               "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
               "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+              "requires": {
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+              },
               "dependencies": {
                 "js-tokens": {
                   "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
@@ -622,6 +995,11 @@
             "concat-stream": {
               "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
               "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+              "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+              },
               "dependencies": {
                 "inherits": {
                   "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -630,6 +1008,15 @@
                 "readable-stream": {
                   "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
                   "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                  "requires": {
+                    "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                    "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  },
                   "dependencies": {
                     "buffer-shims": {
                       "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -649,7 +1036,10 @@
                     },
                     "string_decoder": {
                       "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc="
+                      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                      "requires": {
+                        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                      }
                     },
                     "util-deprecate": {
                       "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -666,6 +1056,9 @@
             "debug": {
               "version": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
               "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
+              "requires": {
+                "ms": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+              },
               "dependencies": {
                 "ms": {
                   "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
@@ -676,6 +1069,10 @@
             "doctrine": {
               "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
               "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+              "requires": {
+                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              },
               "dependencies": {
                 "isarray": {
                   "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -686,62 +1083,129 @@
             "escope": {
               "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
               "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+              "requires": {
+                "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+                "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+                "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+                "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+              },
               "dependencies": {
                 "es6-map": {
                   "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
                   "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                    "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                    "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+                  },
                   "dependencies": {
                     "d": {
                       "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+                      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                      "requires": {
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                      }
                     },
                     "es5-ext": {
                       "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                      "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY="
+                      "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
+                      "requires": {
+                        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                      }
                     },
                     "es6-iterator": {
                       "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI="
+                      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+                      "requires": {
+                        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                      }
                     },
                     "es6-set": {
                       "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE="
+                      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+                      "requires": {
+                        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+                      }
                     },
                     "es6-symbol": {
                       "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
+                      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                      "requires": {
+                        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                      }
                     },
                     "event-emitter": {
                       "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-                      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk="
+                      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+                      "requires": {
+                        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                      }
                     }
                   }
                 },
                 "es6-weak-map": {
                   "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
                   "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                  },
                   "dependencies": {
                     "d": {
                       "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+                      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                      "requires": {
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                      }
                     },
                     "es5-ext": {
                       "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                      "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY="
+                      "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
+                      "requires": {
+                        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                      }
                     },
                     "es6-iterator": {
                       "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI="
+                      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+                      "requires": {
+                        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                      }
                     },
                     "es6-symbol": {
                       "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
+                      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                      "requires": {
+                        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                      }
                     }
                   }
                 },
                 "esrecurse": {
                   "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
                   "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+                  "requires": {
+                    "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                  },
                   "dependencies": {
                     "estraverse": {
                       "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
@@ -758,6 +1222,10 @@
             "espree": {
               "version": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
               "integrity": "sha1-ONve2+3JW4lhofvwRzSo9qnIxZI=",
+              "requires": {
+                "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+                "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+              },
               "dependencies": {
                 "acorn": {
                   "version": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
@@ -766,6 +1234,9 @@
                 "acorn-jsx": {
                   "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
                   "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+                  "requires": {
+                    "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+                  },
                   "dependencies": {
                     "acorn": {
                       "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
@@ -777,7 +1248,10 @@
             },
             "esquery": {
               "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-              "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo="
+              "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+              "requires": {
+                "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+              }
             },
             "estraverse": {
               "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
@@ -790,10 +1264,20 @@
             "file-entry-cache": {
               "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
               "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+              "requires": {
+                "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+              },
               "dependencies": {
                 "flat-cache": {
                   "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
                   "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+                  "requires": {
+                    "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+                    "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                    "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                  },
                   "dependencies": {
                     "circular-json": {
                       "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
@@ -802,14 +1286,34 @@
                     "del": {
                       "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
                       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                      "requires": {
+                        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+                      },
                       "dependencies": {
                         "globby": {
                           "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
                           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                          "requires": {
+                            "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                            "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+                          },
                           "dependencies": {
                             "array-union": {
                               "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
                               "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                              "requires": {
+                                "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+                              },
                               "dependencies": {
                                 "array-uniq": {
                                   "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -830,10 +1334,16 @@
                         "is-path-in-cwd": {
                           "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                           "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+                          "requires": {
+                            "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                          },
                           "dependencies": {
                             "is-path-inside": {
                               "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                              "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838="
+                              "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+                              "requires": {
+                                "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+                              }
                             }
                           }
                         },
@@ -844,6 +1354,9 @@
                         "pinkie-promise": {
                           "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "requires": {
+                            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -853,7 +1366,10 @@
                         },
                         "rimraf": {
                           "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+                          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+                          "requires": {
+                            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+                          }
                         }
                       }
                     },
@@ -863,7 +1379,10 @@
                     },
                     "write": {
                       "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c="
+                      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+                      "requires": {
+                        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                      }
                     }
                   }
                 },
@@ -888,6 +1407,21 @@
             "inquirer": {
               "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
               "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+              "requires": {
+                "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+                "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+                "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+                "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              },
               "dependencies": {
                 "ansi-escapes": {
                   "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -900,10 +1434,17 @@
                 "cli-cursor": {
                   "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
                   "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                  "requires": {
+                    "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+                  },
                   "dependencies": {
                     "restore-cursor": {
                       "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                      "requires": {
+                        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+                        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                      },
                       "dependencies": {
                         "exit-hook": {
                           "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -924,6 +1465,10 @@
                 "figures": {
                   "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
                   "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                  "requires": {
+                    "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                  },
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -938,6 +1483,11 @@
                 "readline2": {
                   "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
                   "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+                  "requires": {
+                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -946,6 +1496,9 @@
                     "is-fullwidth-code-point": {
                       "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "requires": {
+                        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -962,10 +1515,16 @@
                 "run-async": {
                   "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
                   "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+                  "requires": {
+                    "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+                  },
                   "dependencies": {
                     "once": {
                       "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "requires": {
+                        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -982,6 +1541,11 @@
                 "string-width": {
                   "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "requires": {
+                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -990,6 +1554,9 @@
                     "is-fullwidth-code-point": {
                       "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "requires": {
+                        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -1001,7 +1568,10 @@
                 },
                 "strip-ansi": {
                   "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "requires": {
+                    "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                  }
                 },
                 "through": {
                   "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1012,6 +1582,12 @@
             "is-my-json-valid": {
               "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
               "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+              "requires": {
+                "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              },
               "dependencies": {
                 "generate-function": {
                   "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -1020,6 +1596,9 @@
                 "generate-object-property": {
                   "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                  "requires": {
+                    "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                  },
                   "dependencies": {
                     "is-property": {
                       "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -1040,6 +1619,9 @@
             "is-resolvable": {
               "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
               "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+              "requires": {
+                "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+              },
               "dependencies": {
                 "tryit": {
                   "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -1050,10 +1632,17 @@
             "js-yaml": {
               "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
               "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
+              "requires": {
+                "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+              },
               "dependencies": {
                 "argparse": {
                   "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+                  "requires": {
+                    "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                  },
                   "dependencies": {
                     "sprintf-js": {
                       "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1070,6 +1659,9 @@
             "json-stable-stringify": {
               "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+              "requires": {
+                "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+              },
               "dependencies": {
                 "jsonify": {
                   "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -1080,6 +1672,10 @@
             "levn": {
               "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
               "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+              "requires": {
+                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+              },
               "dependencies": {
                 "prelude-ls": {
                   "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1087,13 +1683,19 @@
                 },
                 "type-check": {
                   "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I="
+                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                  "requires": {
+                    "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                  }
                 }
               }
             },
             "mkdirp": {
               "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -1108,6 +1710,14 @@
             "optionator": {
               "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
               "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+              "requires": {
+                "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+              },
               "dependencies": {
                 "deep-is": {
                   "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1123,7 +1733,10 @@
                 },
                 "type-check": {
                   "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I="
+                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                  "requires": {
+                    "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                  }
                 },
                 "wordwrap": {
                   "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -1146,10 +1759,17 @@
             "require-uncached": {
               "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
               "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+              "requires": {
+                "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+                "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+              },
               "dependencies": {
                 "caller-path": {
                   "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
                   "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+                  "requires": {
+                    "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+                  },
                   "dependencies": {
                     "callsites": {
                       "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
@@ -1166,6 +1786,11 @@
             "shelljs": {
               "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
               "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+              "requires": {
+                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+                "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+              },
               "dependencies": {
                 "interpret": {
                   "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
@@ -1174,10 +1799,16 @@
                 "rechoir": {
                   "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
                   "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+                  "requires": {
+                    "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+                  },
                   "dependencies": {
                     "resolve": {
                       "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
                       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+                      "requires": {
+                        "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+                      },
                       "dependencies": {
                         "path-parse": {
                           "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
@@ -1200,10 +1831,22 @@
             "table": {
               "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
               "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+              "requires": {
+                "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+                "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+                "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
+              },
               "dependencies": {
                 "ajv": {
                   "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
                   "integrity": "sha1-hlWl2G0IJJhcxHGh2RP7Zymg7Eg=",
+                  "requires": {
+                    "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+                  },
                   "dependencies": {
                     "co": {
                       "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1222,6 +1865,10 @@
                 "string-width": {
                   "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
                   "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+                  "requires": {
+                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                  },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1230,6 +1877,9 @@
                     "strip-ansi": {
                       "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "requires": {
+                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -1248,6 +1898,9 @@
             "user-home": {
               "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
               "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+              "requires": {
+                "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+              },
               "dependencies": {
                 "os-homedir": {
                   "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -1260,6 +1913,14 @@
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "requires": {
+            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          },
           "dependencies": {
             "fs.realpath": {
               "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1268,6 +1929,10 @@
             "inflight": {
               "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1282,10 +1947,17 @@
             "minimatch": {
               "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "requires": {
+                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                  "requires": {
+                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -1302,6 +1974,9 @@
             "once": {
               "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "requires": {
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1318,6 +1993,12 @@
         "handlebars": {
           "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
           "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
+          "requires": {
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz"
+          },
           "dependencies": {
             "async": {
               "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -1326,6 +2007,10 @@
             "optimist": {
               "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+              "requires": {
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
@@ -1340,6 +2025,9 @@
             "source-map": {
               "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "requires": {
+                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+              },
               "dependencies": {
                 "amdefine": {
                   "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -1351,6 +2039,11 @@
               "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
               "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
               "optional": true,
+              "requires": {
+                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+              },
               "dependencies": {
                 "source-map": {
                   "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
@@ -1366,6 +2059,12 @@
                   "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                   "optional": true,
+                  "requires": {
+                    "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                    "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  },
                   "dependencies": {
                     "camelcase": {
                       "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -1376,21 +2075,38 @@
                       "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                       "optional": true,
+                      "requires": {
+                        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      },
                       "dependencies": {
                         "center-align": {
                           "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                           "optional": true,
+                          "requires": {
+                            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                               "optional": true,
+                              "requires": {
+                                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
                                   "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
                                   "optional": true,
+                                  "requires": {
+                                    "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
@@ -1422,16 +2138,27 @@
                           "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                           "optional": true,
+                          "requires": {
+                            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                               "optional": true,
+                              "requires": {
+                                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
                                   "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
                                   "optional": true,
+                                  "requires": {
+                                    "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
@@ -1480,6 +2207,22 @@
         "istanbul": {
           "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
           "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+          "requires": {
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+            "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+          },
           "dependencies": {
             "abbrev": {
               "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -1492,6 +2235,13 @@
             "escodegen": {
               "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
               "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+              "requires": {
+                "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+              },
               "dependencies": {
                 "estraverse": {
                   "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -1504,6 +2254,14 @@
                 "optionator": {
                   "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
                   "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+                  "requires": {
+                    "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                    "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                    "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                    "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                    "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                    "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                  },
                   "dependencies": {
                     "deep-is": {
                       "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1515,7 +2273,11 @@
                     },
                     "levn": {
                       "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4="
+                      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                      "requires": {
+                        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                      }
                     },
                     "prelude-ls": {
                       "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1523,7 +2285,10 @@
                     },
                     "type-check": {
                       "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I="
+                      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                      "requires": {
+                        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                      }
                     }
                   }
                 },
@@ -1531,6 +2296,9 @@
                   "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                   "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                   "optional": true,
+                  "requires": {
+                    "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                  },
                   "dependencies": {
                     "amdefine": {
                       "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -1548,10 +2316,21 @@
             "glob": {
               "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "requires": {
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+              },
               "dependencies": {
                 "inflight": {
                   "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                  "requires": {
+                    "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1566,10 +2345,17 @@
                 "minimatch": {
                   "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                  "requires": {
+                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                      "requires": {
+                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -1592,10 +2378,17 @@
             "js-yaml": {
               "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
               "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
+              "requires": {
+                "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+              },
               "dependencies": {
                 "argparse": {
                   "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+                  "requires": {
+                    "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                  },
                   "dependencies": {
                     "sprintf-js": {
                       "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1612,6 +2405,9 @@
             "mkdirp": {
               "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -1621,11 +2417,17 @@
             },
             "nopt": {
               "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "requires": {
+                "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+              }
             },
             "once": {
               "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "requires": {
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1640,6 +2442,9 @@
             "supports-color": {
               "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "requires": {
+                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              },
               "dependencies": {
                 "has-flag": {
                   "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -1650,6 +2455,9 @@
             "which": {
               "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
               "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+              "requires": {
+                "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+              },
               "dependencies": {
                 "isexe": {
                   "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1670,6 +2478,19 @@
         "mocha": {
           "version": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
           "integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
+          "requires": {
+            "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+            "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+            "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+            "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+            "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          },
           "dependencies": {
             "browser-stdout": {
               "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
@@ -1678,6 +2499,9 @@
             "commander": {
               "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+              "requires": {
+                "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+              },
               "dependencies": {
                 "graceful-readlink": {
                   "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
@@ -1688,6 +2512,9 @@
             "debug": {
               "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
               "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+              "requires": {
+                "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+              },
               "dependencies": {
                 "ms": {
                   "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -1714,10 +2541,19 @@
             "lodash.create": {
               "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
               "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+              "requires": {
+                "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+              },
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+                  "requires": {
+                    "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                    "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                  },
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -1726,6 +2562,11 @@
                     "lodash.keys": {
                       "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                      "requires": {
+                        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      },
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
@@ -1756,6 +2597,9 @@
             "mkdirp": {
               "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -1766,6 +2610,9 @@
             "supports-color": {
               "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "requires": {
+                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              },
               "dependencies": {
                 "has-flag": {
                   "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -1778,14 +2625,26 @@
         "nymag-fs": {
           "version": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.0.tgz",
           "integrity": "sha1-CKUKYWbMiiL3qjJVaHQ53sVQBFk=",
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+            "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          },
           "dependencies": {
             "js-yaml": {
               "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
               "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
+              "requires": {
+                "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+              },
               "dependencies": {
                 "argparse": {
                   "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+                  "requires": {
+                    "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                  },
                   "dependencies": {
                     "sprintf-js": {
                       "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1804,14 +2663,28 @@
         "pre-commit": {
           "version": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
           "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+          "requires": {
+            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+          },
           "dependencies": {
             "cross-spawn": {
               "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "requires": {
+                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+                "shebang-command": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+              },
               "dependencies": {
                 "lru-cache": {
                   "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
                   "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+                  "requires": {
+                    "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+                  },
                   "dependencies": {
                     "pseudomap": {
                       "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1826,6 +2699,9 @@
                 "shebang-command": {
                   "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
                   "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                  "requires": {
+                    "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                  },
                   "dependencies": {
                     "shebang-regex": {
                       "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
@@ -1838,10 +2714,19 @@
             "spawn-sync": {
               "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
               "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+              "requires": {
+                "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                "os-shim": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+              },
               "dependencies": {
                 "concat-stream": {
                   "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
                   "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+                  "requires": {
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                    "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                  },
                   "dependencies": {
                     "inherits": {
                       "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -1850,6 +2735,15 @@
                     "readable-stream": {
                       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
                       "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                      "requires": {
+                        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      },
                       "dependencies": {
                         "buffer-shims": {
                           "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -1869,7 +2763,10 @@
                         },
                         "string_decoder": {
                           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                          "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc="
+                          "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                          "requires": {
+                            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                          }
                         },
                         "util-deprecate": {
                           "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1892,6 +2789,9 @@
             "which": {
               "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
               "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+              "requires": {
+                "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+              },
               "dependencies": {
                 "isexe": {
                   "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1904,6 +2804,16 @@
         "sinon": {
           "version": "https://registry.npmjs.org/sinon/-/sinon-2.1.0.tgz",
           "integrity": "sha1-4Fep0r8bMvXW3WJijKnuOWGwyvs=",
+          "requires": {
+            "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+            "formatio": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+            "lolex": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+            "native-promise-only": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+            "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+            "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+            "text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+            "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+          },
           "dependencies": {
             "diff": {
               "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
@@ -1911,7 +2821,10 @@
             },
             "formatio": {
               "version": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-              "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs="
+              "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+              "requires": {
+                "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
+              }
             },
             "lolex": {
               "version": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
@@ -1924,6 +2837,9 @@
             "path-to-regexp": {
               "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
               "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+              "requires": {
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              },
               "dependencies": {
                 "isarray": {
                   "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -1948,15 +2864,18 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -1965,6 +2884,11 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -1981,11 +2905,18 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.0.3",
@@ -1996,12 +2927,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -2013,7 +2947,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -2021,9 +2960,9 @@
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.3.1",
@@ -2038,14 +2977,20 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -2057,14 +3002,38 @@
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
         }
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "cssmin": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
+      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
       "dev": true
     },
     "cycle": {
@@ -2072,17 +3041,14 @@
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
-    "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2093,9 +3059,12 @@
       }
     },
     "debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2109,6 +3078,9 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
@@ -2128,7 +3100,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -2137,9 +3118,9 @@
       "dev": true
     },
     "depd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "destroy": {
       "version": "1.0.4",
@@ -2156,14 +3137,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2174,6 +3162,14 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.0.0.tgz",
       "integrity": "sha1-f5W9v/XK1jelO+YT3bmt83cM71g=",
+      "requires": {
+        "agentkeepalive": "2.2.0",
+        "chalk": "1.1.3",
+        "lodash": "2.4.2",
+        "lodash.get": "4.4.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.trimend": "4.5.1"
+      },
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
@@ -2187,41 +3183,13 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
-    "es5-ext": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
-    },
-    "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
-    },
-    "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
-    },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
-    },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
-    },
-    "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2238,6 +3206,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -2253,47 +3228,148 @@
         }
       }
     },
-    "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
-    },
     "eslint": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
+      "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.3.0",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.0",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.5.1",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.2.1",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
       }
     },
     "estraverse": {
@@ -2309,26 +3385,58 @@
       "dev": true
     },
     "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "express": {
-      "version": "4.15.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
-      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI="
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "requires": {
+        "accepts": "1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        }
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -2336,10 +3444,21 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.6.0",
+        "tmp": "0.0.33"
+      }
+    },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "eyes": {
@@ -2347,34 +3466,90 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-parse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.1.tgz",
+      "integrity": "sha512-g2UqeO0yyYjTSpiH4zJQk+IycRxyYRABjSf+TpmeMOn9uByzFIoX0y/HnweCFhKb+uuPwjIvqXuK/LTteEBhow=="
+    },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
     },
     "finalhandler": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        }
+      }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "flatstr": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.5.tgz",
+      "integrity": "sha1-W0UbCMvUji6sVKK74L9GFlqhS+M="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2386,28 +3561,42 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
     },
     "formatio": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
     },
     "forwarded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "generate-function": {
       "version": "2.0.0",
@@ -2419,13 +3608,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2438,7 +3633,15 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -2450,7 +3653,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -2471,10 +3682,16 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -2486,7 +3703,10 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -2494,23 +3714,43 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.11.0",
+        "is-my-json-valid": "2.16.1",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
     "hoek": {
@@ -2520,25 +3760,36 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc="
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.4.0"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "iconv-lite": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -2550,7 +3801,11 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -2558,39 +3813,101 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
-    },
-    "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "ipaddr.js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
-      "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -2602,12 +3919,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-property": {
@@ -2620,7 +3949,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2631,8 +3963,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2650,6 +3981,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.0.0",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -2661,32 +4008,46 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -2695,17 +4056,38 @@
       "dev": true,
       "optional": true
     },
+    "jschardet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
+      "dev": true
+    },
+    "jsmin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
+      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2732,10 +4114,16 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2745,11 +4133,40 @@
         }
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
+    "jxLoader": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
+      "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "0.3.7",
+        "moo-server": "1.3.0",
+        "promised-io": "0.3.5",
+        "walker": "1.0.7"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
+          "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
+          "dev": true
+        }
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -2768,7 +4185,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -2779,6 +4200,9 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/lodash-ny-util/-/lodash-ny-util-0.1.1.tgz",
       "integrity": "sha1-wlXI8W7y2MO4n/3mNMuOCe9PdTo=",
+      "requires": {
+        "lodash": "3.10.1"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -2791,7 +4215,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -2821,7 +4249,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2849,7 +4282,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.trimend": {
       "version": "4.5.1",
@@ -2863,9 +4301,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
+      "integrity": "sha512-BdHq78SeI+6PAUtl4atDuCt7L6E4fab3mSRtqxm4ywaXe4uP7jZ0TTcFNuU20syUjxZc2l7jFqKVMJ+AX0LnpQ==",
       "dev": true
     },
     "longest": {
@@ -2873,6 +4311,25 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.4"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -2890,24 +4347,36 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -2920,6 +4389,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -2930,36 +4402,79 @@
       }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
         "debug": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
+    },
+    "moo-server": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
+      "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -2967,9 +4482,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "native-promise-only": {
@@ -2989,22 +4504,60 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
     },
     "nymag-fs": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.1.tgz",
-      "integrity": "sha1-STkdL5fktYjNgSeImGqyH61afD4="
+      "integrity": "sha1-STkdL5fktYjNgSeImGqyH61afD4=",
+      "requires": {
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "lodash": "4.17.4"
+      }
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -3021,24 +4574,37 @@
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -3058,18 +4624,26 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
-    "os-homedir": {
+    "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3080,12 +4654,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-to-regexp": {
@@ -3109,12 +4677,57 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pino": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-4.9.0.tgz",
+      "integrity": "sha512-5G/vE3d42EV0opHO8YYwOWwBMAvk9nAsNSPYXxYdIDWHb4FdCqvKzuAq2Wb/9tkLUnSxW+4JSHDiQwwp0Qh4Eg==",
+      "requires": {
+        "chalk": "2.3.0",
+        "fast-json-parse": "1.0.3",
+        "fast-safe-stringify": "1.2.1",
+        "flatstr": "1.0.5",
+        "pump": "1.0.2",
+        "quick-format-unescaped": "1.1.1",
+        "split2": "2.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -3126,13 +4739,12 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
     "promise-queue": {
@@ -3140,10 +4752,35 @@
       "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.3.tgz",
       "integrity": "sha1-hTTXa/RnPDuqOoK7oBvSlcww8U8="
     },
+    "promised-io": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
+      "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=",
+      "dev": true
+    },
     "proxy-addr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "pump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "once": "1.4.0"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -3152,9 +4789,17 @@
       "dev": true
     },
     "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "quick-format-unescaped": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.1.tgz",
+      "integrity": "sha1-53VV7z5m4QXUA54T73kgEoT+6RY=",
+      "requires": {
+        "fast-safe-stringify": "1.2.1"
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -3162,27 +4807,29 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
     },
     "readable-stream": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-      "dev": true
-    },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -3195,6 +4842,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
       "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "qs": {
           "version": "6.3.2",
@@ -3208,12 +4877,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
     "resolve-from": {
@@ -3223,74 +4896,157 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
     "send": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk="
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        }
+      }
     },
     "serve-static": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
+      }
     },
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "sinon": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.4.tgz",
-      "integrity": "sha1-RmrY0brobW21GqIYuS6Ze8Pl24g=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
+      "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
       "dev": true,
+      "requires": {
+        "build": "0.1.4",
+        "diff": "3.2.0",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.1.3",
+        "native-promise-only": "0.8.1",
+        "nise": "1.2.0",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.3.0",
+        "text-encoding": "0.6.4",
+        "type-detect": "4.0.3"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -3302,7 +5058,10 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
         },
         "type-detect": {
           "version": "4.0.3",
@@ -3313,23 +5072,40 @@
       }
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "source-map": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "2.0.3"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3341,6 +5117,16 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3356,21 +5142,44 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-    },
-    "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3381,13 +5190,10 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -3401,22 +5207,47 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
+      "requires": {
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.0",
+        "lodash": "4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
         },
-        "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -3438,11 +5269,44 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "timespan": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
+      "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tryit": {
       "version": "1.0.3",
@@ -3467,7 +5331,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "1.0.0",
@@ -3478,7 +5345,11 @@
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.17"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -3492,11 +5363,16 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         }
@@ -3514,16 +5390,13 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
-    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -3535,13 +5408,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.1.0",
@@ -3550,21 +5422,46 @@
       "dev": true
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.11"
+      }
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -3574,9 +5471,17 @@
       "optional": true
     },
     "winston": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -3589,16 +5494,30 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "wrench": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
+      "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
+      "dev": true
+    },
     "write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
@@ -3606,7 +5525,13 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }


### PR DESCRIPTION
**Summary:** while the `clay-log` util was integrated into the project, errors were being thrown rather than being logged in the expected format. To actually use cool log search tooling those errors need to be logged in the proper format.

**Additional Updates:** 
- Stronger assumptions about what should break a Clay instance were added. Two examples are if the `sites` index fails to be populated or if no Elastic endpoint are provided.
- Tests were updated to stop having unhandled rejections of promises
- False positives for tests were also updated.
- `package-lock.json` added and the Circle env was updated to Node `8.9.0`