### PR TITLE
Breaking Change: Single Types

### DIFF
--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -180,7 +180,7 @@ function updatePageData(pageUri, data) {
     return bluebird.reject(err);
   }
 
-  return elastic.update(PAGES_INDEX, 'general', pageUri, data, true)
+  return elastic.update(PAGES_INDEX, pageUri, data, true)
     .then(function (result) {
       log('debug', `Page data updates for page: ${result._id}` );
       return result;
@@ -197,7 +197,7 @@ function updatePageData(pageUri, data) {
  * @return {Promise}
  */
 function getPage(pageUri) {
-  return elastic.getDocument(PAGES_INDEX, 'general', pageUri);
+  return elastic.getDocument(PAGES_INDEX, pageUri);
 }
 
 
@@ -209,28 +209,19 @@ function getPage(pageUri) {
  * @return {Function}
  */
 function updatePageList(batchOps) {
-  return helpers.applyOpFilters(batchOps, setup.mappings, PAGES_INDEX, filterForPageOps)
-    .then(function (resp) {
-      var resp = _.get(resp, '[0][0]'),
-        filteredOps,
-        typeName;
+  return helpers.applyOpFilters(batchOps, PAGES_INDEX, filterForPageOps)
+    .then(function (filteredOps) {
+      if (filteredOps && filteredOps.length) {
+        return module.exports.pageExists(filteredOps)
+          .then(function (existsArr) {
+            var dividedOps = categorizeOps(filteredOps, existsArr);
 
-      if (resp) {
-        filteredOps = resp.ops;
-        typeName = resp.typeName;
-
-        if (filteredOps) {
-          return module.exports.pageExists(filteredOps)
-            .then(function (existsArr) {
-              var dividedOps = categorizeOps(filteredOps, existsArr);
-
-              if (dividedOps.existing.length) {
-                return module.exports.updateExistingPageData(dividedOps.existing);
-              } else {
-                return elastic.batch(elastic.convertRedisBatchtoElasticBatch(PAGES_INDEX, typeName, module.exports.constructPageData(filteredOps)));
-              }
-            });
-        }
+            if (dividedOps.existing.length) {
+              return module.exports.updateExistingPageData(dividedOps.existing);
+            } else {
+              return elastic.batch(elastic.convertRedisBatchtoElasticBatch(PAGES_INDEX, module.exports.constructPageData(filteredOps)));
+            }
+          });
       }
     });
 }
@@ -335,7 +326,7 @@ function findPageAndUpdate(reqObj, res) {
   }
 
   return queue.add(function () {
-    return elastic.query(PAGES_INDEX, constructFindQuery(reqObj.url), 'general')
+    return elastic.query(PAGES_INDEX, constructFindQuery(reqObj.url))
       .then(module.exports.updatePageListEntry(reqObj.value));
   }).then(function () {
     res.status(200);

--- a/lib/page-list.test.js
+++ b/lib/page-list.test.js
@@ -205,15 +205,9 @@ describe(_.startCase(filename), function () {
     });
 
     it('it does nothing if there are not filteredOps', function () {
-      var sampleOps = [{
-        ops: null,
-        mapping: null,
-        type: 'general'
-      }];
+      helpers.applyOpFilters.returns(Promise.resolve(null));
 
-      helpers.applyOpFilters.returns(Promise.resolve([sampleOps]));
-
-      return fn(sampleOps).then(function () {
+      return fn().then(function () {
         expect(search.batch.calledOnce).to.be.false;
       });
     });

--- a/lib/routes/_sites.js
+++ b/lib/routes/_sites.js
@@ -31,7 +31,7 @@ function response(req, res) {
  * @return {function}
  */
 function querySites() {
-  return elastic.query(helpers.indexWithPrefix('sites'), { size: 50 }, 'general')
+  return elastic.query(helpers.indexWithPrefix('sites'), { size: 50 })
     .then((result) => _.get(result, 'hits.hits', []));
 }
 

--- a/lib/routes/_sites.test.js
+++ b/lib/routes/_sites.test.js
@@ -54,7 +54,7 @@ describe(_.startCase(filename), function () {
       elastic.query.returns(Promise.resolve(response));
       return fn()
         .then(() => {
-          expect(elastic.query.calledWith('sites', { size: 50 }, 'general')).to.be.true;
+          expect(elastic.query.calledWith('sites', { size: 50 })).to.be.true;
         });
     });
 

--- a/lib/routes/_update.js
+++ b/lib/routes/_update.js
@@ -36,9 +36,9 @@ function validateUpdateRequest(updateBody) {
  */
 function elasticPassthrough(updateBody) {
   return function () {
-    var { index, type, id, body, refresh } = validateUpdateRequest(updateBody);
+    var { index, id, body, refresh } = validateUpdateRequest(updateBody);
 
-    return elastic.update(index, type, id, body, refresh);
+    return elastic.update(index, id, body, refresh);
   };
 }
 

--- a/lib/routes/_update.js
+++ b/lib/routes/_update.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const elastic = require('../services/elastic'),
+  bluebird = require('bluebird'),
   helpers = require('../services/elastic-helpers'),
   responses = require('../services/responses'),
   log = require('../services/log').setup({ file: __filename });
@@ -13,11 +14,12 @@ const elastic = require('../services/elastic'),
  * @return {Object}
  */
 function validateUpdateRequest(updateBody) {
-  if (!updateBody.index || !updateBody.type || !updateBody.id || !updateBody.body) {
-    let err = new Error('An index, type, id, and body property are all required to update');
+  if (!updateBody.index || !updateBody.id || !updateBody.body) {
+    let err = new Error('An index, id, and body property are all required to update');
 
     log('error', err.message, { stack: err.stack });
-    return bluebird.reject(err);
+    throw err;
+    // return bluebird.reject(err);
   }
 
   updateBody.index = helpers.indexWithPrefix(updateBody.index);

--- a/lib/routes/_update.js
+++ b/lib/routes/_update.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const elastic = require('../services/elastic'),
-  bluebird = require('bluebird'),
   helpers = require('../services/elastic-helpers'),
   responses = require('../services/responses'),
   log = require('../services/log').setup({ file: __filename });
@@ -19,7 +18,6 @@ function validateUpdateRequest(updateBody) {
 
     log('error', err.message, { stack: err.stack });
     throw err;
-    // return bluebird.reject(err);
   }
 
   updateBody.index = helpers.indexWithPrefix(updateBody.index);

--- a/lib/routes/_update.test.js
+++ b/lib/routes/_update.test.js
@@ -46,35 +46,30 @@ describe(_.startCase(filename), function () {
   });
 
   describe('elasticPassthrough', function () {
-    const fn = lib[this.title];
+    const fn = lib[this.title],
+      errMsg = 'An index, id, and body property are all required to update';
 
     it('queries Elastic', function () {
-      var callback = fn({index: 'pages', type: 'general', id: 'id', body: 'body'});
+      var callback = fn({index: 'pages', id: 'id', body: 'body'});
 
       callback();
       expect(elastic.update.calledWith('pages', 'id', 'body')).to.be.true;
     });
 
     it('throws an error if there is no index', function () {
-      var callback = fn({type: 'general', id: 'id', body: 'body'});
-
-      expect(callback).to.throw(Error);
-    });
-
-    it('throws an error if there is no type', function () {
-      var callback = fn({index: 'pages', id: 'id', body: 'body'});
+      var callback = fn({id: 'id', body: 'body'});
 
       expect(callback).to.throw(Error);
     });
 
     it('throws an error if there is no id', function () {
-      var callback = fn({index: 'pages', type: 'general', body: 'body'});
+      var callback = fn({index: 'pages', body: 'body'});
 
       expect(callback).to.throw(Error);
     });
 
     it('throws an error if there is no body', function () {
-      var callback = fn({index: 'pages', type: 'general', id: 'id'});
+      var callback = fn({index: 'pages', id: 'id'});
 
       expect(callback).to.throw(Error);
     });

--- a/lib/routes/_update.test.js
+++ b/lib/routes/_update.test.js
@@ -46,8 +46,7 @@ describe(_.startCase(filename), function () {
   });
 
   describe('elasticPassthrough', function () {
-    const fn = lib[this.title],
-      errMsg = 'An index, id, and body property are all required to update';
+    const fn = lib[this.title];
 
     it('queries Elastic', function () {
       var callback = fn({index: 'pages', id: 'id', body: 'body'});

--- a/lib/routes/_update.test.js
+++ b/lib/routes/_update.test.js
@@ -52,7 +52,7 @@ describe(_.startCase(filename), function () {
       var callback = fn({index: 'pages', type: 'general', id: 'id', body: 'body'});
 
       callback();
-      expect(elastic.update.calledWith('pages', 'general', 'id', 'body')).to.be.true;
+      expect(elastic.update.calledWith('pages', 'id', 'body')).to.be.true;
     });
 
     it('throws an error if there is no index', function () {

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -166,7 +166,6 @@ function convertOpValuesPropertyToString(propertyName, ops) {
  * @param {Array}  options.ops
  * @param {string} [options.action] defaults to `index`, can use `create`, `index`, `update`, `delete`
  * @param {boolean} [options.docAsUpsert] if true and action is `update`, then it will create entry if not already indexed
- * @throws will throw an error if options.action is not supported
  * @returns {Array}
  */
 function convertRedisBatchtoElasticBatch(options) {

--- a/lib/services/elastic-helpers.js
+++ b/lib/services/elastic-helpers.js
@@ -4,7 +4,9 @@
 const _ = require('lodash'),
   bluebird = require('bluebird'),
   refProp = '_ref',
-  setup = require('../setup');
+  setup = require('../setup'),
+  FIXED_TYPE = 'general';
+
 var log = require('./log').setup({file: __filename}),
   genericTypeParsers = [{ // used to test Elastic data types
     when: compare('string'),
@@ -170,7 +172,6 @@ function convertOpValuesPropertyToString(propertyName, ops) {
 function convertRedisBatchtoElasticBatch(options) {
   let bulkOps = [],
     index = options.index,
-    type = options.type,
     ops = options.ops,
     action = options.action || 'index'; // default to overwrite document
 
@@ -180,7 +181,7 @@ function convertRedisBatchtoElasticBatch(options) {
     }
 
     if (op.type === 'put') {
-      let indexOp = { _index: index, _type: type },
+      let indexOp = { _index: index, _type: FIXED_TYPE },
         requestMetadata = {},
         requestBody;
 
@@ -227,13 +228,13 @@ function convertRedisBatchtoElasticBatch(options) {
  *
  * We don't care about the other properties.
  *
- * @param {Object} mapping
+ * @param {string} index
  * @param {Array} ops
  * @returns {Promise}
  */
-function normalizeOpValuesWithMapping(mapping, ops) {
+function normalizeOpValuesWithMapping(index, ops) {
   var promises,
-    properties = mapping.properties;
+    { properties } = setup.mappings[stripPrefix(index)][FIXED_TYPE]; // Look in the mappings for the index and get the only type we support
 
   promises = _.map(properties, function (property, propertyName) {
     var type = property.type,
@@ -250,29 +251,20 @@ function normalizeOpValuesWithMapping(mapping, ops) {
 }
 
 /**
- * Iterate through the mappings and types and invoke a function
- * (which is passed in by the user) to filter the ops down to what
- * is necessary for a specific index.
+ * Given ops and an index name,
  *
- * @param  {Array}    batchOps      db operations
- * @param  {Object}   mappings      keys are index names, and values are index mapping settings
+ * @param  {Array}    ops      db operations
  * @param  {String}   indexName     name of the elastic search index
  * @param  {Function} opsTransform  function given batchOps that returns a Promise or object
- * @return {Promise.<[[{ops: {}, mapping: {}, typeName: string}]]>}
+ * @return {Promise}
  */
-function applyOpFilters(batchOps, mappings, indexName, opsTransform) {
-  indexName = stripPrefix(indexName); // Trim the prefix off the index for comparing against mapping names
+function applyOpFilters(ops, indexName, opsTransform) {
+  var mapping;
 
-  return bluebird.all(_.map(_.pick(mappings, indexName), function (types) {
-    return bluebird.all(_.map(types, function (mapping, typeName) {
-      return bluebird.resolve(opsTransform(batchOps))
-        .then(transformedOps => ({
-          ops: transformedOps,
-          mapping: mapping, // TODO: May not need to return mapping
-          typeName: typeName
-        }));
-    }));
-  }));
+  indexName = stripPrefix(indexName); // Trim the prefix off the index for comparing against mapping names
+  mapping = JSON.parse(JSON.stringify(setup.mappings[stripPrefix(indexName)]));
+
+  return bluebird.try(opsTransform.bind(null, ops, mapping));
 }
 
 /**

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -17,7 +17,10 @@ describe(_.startCase(filename), function () {
           general: {
             dynamic: false,
             properties: {
-              propertyName: { type: 'string', index: 'analyzed' }
+              propertyName: { type: 'string', index: 'analyzed' },
+              otherProperty: { type: 'object', index: 'analyzed' },
+              oneMoreProperty: { type: 'date', index: 'analyzed' },
+              oneMoreProperty: { type: 'number', index: 'analyzed' } // Not supported in normalizeOpValuesWithMapping to test an `else`
             }
           }
         }
@@ -35,6 +38,28 @@ describe(_.startCase(filename), function () {
     afterEach(function () {
       sandbox.restore();
       setup.mappings = {};
+    });
+
+    describe('stripPrefix', function () {
+      const fn = lib[this.title];
+
+      it('removes a prefix if one exists', function () {
+        setup.prefix = 'test';
+
+        expect(fn('test_index')).to.equal('index');
+        setup.prefix = '';
+      });
+    });
+
+    describe('indexWithPrefix', function () {
+      const fn = lib[this.title];
+
+      it('adds a prefix if one exists', function () {
+        setup.prefix = ' test';
+
+        expect(fn('index')).to.equal('test_index');
+        setup.prefix = '';
+      });
     });
 
     describe('convertRedisBatchtoElasticBatch', function () {

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -19,8 +19,8 @@ describe(_.startCase(filename), function () {
             properties: {
               propertyName: { type: 'string', index: 'analyzed' },
               otherProperty: { type: 'object', index: 'analyzed' },
-              oneMoreProperty: { type: 'date', index: 'analyzed' },
-              oneMoreProperty: { type: 'number', index: 'analyzed' } // Not supported in normalizeOpValuesWithMapping to test an `else`
+              oneMoreProperty: { type: 'date' },
+              lastProperty: { type: 'number', index: 'analyzed' } // Not supported in normalizeOpValuesWithMapping to test an `else`
             }
           }
         }

--- a/lib/services/elastic-helpers.test.js
+++ b/lib/services/elastic-helpers.test.js
@@ -11,18 +11,30 @@ const sinon = require('sinon'),
 describe(_.startCase(filename), function () {
   describe(filename, function () {
     var sandbox, logFn,
-      db = { get: _.noop, put: _.noop };
+      db = { get: _.noop, put: _.noop },
+      FAKE_MAPPING = {
+        myIndex: {
+          general: {
+            dynamic: false,
+            properties: {
+              propertyName: { type: 'string', index: 'analyzed' }
+            }
+          }
+        }
+      };
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
       logFn = sandbox.stub();
       sandbox.stub(db, 'get');
       sandbox.stub(db, 'put');
+      setup.mappings = FAKE_MAPPING;
       lib.setLog(logFn);
     });
 
     afterEach(function () {
       sandbox.restore();
+      setup.mappings = {};
     });
 
     describe('convertRedisBatchtoElasticBatch', function () {
@@ -31,19 +43,19 @@ describe(_.startCase(filename), function () {
       it('returns an array of ops if type property equals "put" with a JSON string', function () {
         var ops = [{ value: '{}', type: 'put' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _index: 'index', _type: 'general' } }, {}]);
       });
 
       it('returns an array of ops if type property equals "put" with a JS object', function () {
         var ops = [{ value: {}, type: 'put' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _index: 'index', _type: 'general' } }, {}]);
       });
 
       it('assigns a "key" property if one is defined in the op', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops})).to.deep.equal([{ index: { _id: 'key', _index: 'index', _type: 'general' } }, {}]);
       });
 
       it('assigns a "key" property if one is defined in the op', function () {
@@ -55,25 +67,25 @@ describe(_.startCase(filename), function () {
       it('allows for update', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops, action: 'update'})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'type', _retry_on_conflict: 3 } }, {doc: {}, doc_as_upsert: false}]);
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'update'})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'general', _retry_on_conflict: 3 } }, {doc: {}, doc_as_upsert: false}]);
       });
 
       it('allows for update with upsert', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops, action: 'update', docAsUpsert: true})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'type', _retry_on_conflict: 3 } }, {doc: {}, doc_as_upsert: true}]);
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'update', docAsUpsert: true})).to.deep.equal([{ update: { _id: 'key', _index: 'index', _type: 'general', _retry_on_conflict: 3 } }, {doc: {}, doc_as_upsert: true}]);
       });
 
       it('allows for delete', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops, action: 'delete'})).to.deep.equal([{ delete: { _id: 'key', _index: 'index', _type: 'type' } }]);
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'delete'})).to.deep.equal([{ delete: { _id: 'key', _index: 'index', _type: 'general' } }]);
       });
 
       it('allows for create', function () {
         var ops = [{ value: '{}', type: 'put', key: 'key' }];
 
-        expect(fn({index: 'index', type: 'type', ops: ops, action: 'create'})).to.deep.equal([{ create: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
+        expect(fn({index: 'index', type: 'type', ops: ops, action: 'create'})).to.deep.equal([{ create: { _id: 'key', _index: 'index', _type: 'general' } }, {}]);
       });
 
       it('logs on unsupported action', function () {
@@ -156,14 +168,11 @@ describe(_.startCase(filename), function () {
             key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
             value:
             { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ],
-          mapping = { dynamic: false,
-            properties:
-             { primaryHeadline: { type: 'string', index: 'analyzed' } }},
           result = [ { type: 'put',
             key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
             value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
 
-        fn(mapping, op).then(function (data) {
+        fn('myIndex', op).then(function (data) {
           expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
@@ -172,14 +181,11 @@ describe(_.startCase(filename), function () {
         let op = [ { type: 'put',
             key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
             value: {feeds: {sitemaps: true, rss: true, newsfeed: true} }} ],
-          mapping = { dynamic: false,
-            properties:
-             { feeds: { type: 'object', index: 'analyzed' } }},
           result = [ { type: 'put',
             key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
             value: {feeds: {sitemaps: true, rss: true, newsfeed: true} }} ];
 
-        fn(mapping, op).then(function (data) {
+        fn('myIndex', op).then(function (data) {
           expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
@@ -189,14 +195,11 @@ describe(_.startCase(filename), function () {
             key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
             value:
             { date: '2016-11-20' } } ],
-          mapping = { dynamic: false,
-            properties:
-             { date: { type: 'date' } }},
           result = [ { type: 'put',
             key: 'localhost.dev.nymag.biz/daily/intelligencer/components/article/instances/civzg5hje000kvurehqsgzcpy',
             value: { date: '2016-11-20' } } ];
 
-        fn(mapping, op).then(function (data) {
+        fn('myIndex', op).then(function (data) {
           expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
@@ -206,13 +209,11 @@ describe(_.startCase(filename), function () {
             key: 'localhost/sitename/components/foo/instances/xyz',
             value:
             { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ],
-          mapping = {properties:
-             { primaryHeadline: { type: 'foo', index: 'analyzed' } }},
           result = [ { type: 'put',
             key: 'localhost/sitename/components/foo/instances/xyz',
             value: { primaryHeadline: 'Blaming Clinton’s Base for Her Loss' } } ];
 
-        fn(mapping, op).then(function (data) {
+        fn('myIndex', op).then(function (data) {
           expect(JSON.stringify(data)).to.equal(JSON.stringify(result));
         });
       });
@@ -243,37 +244,14 @@ describe(_.startCase(filename), function () {
           key: 'localhost/components/foo/instances/xyz',
           value: { propertyName:'' }
         }],
-        mappings = {
-          myIndex: {
-            general: {
-              dynamic: false,
-              properties: {
-                propertyName: { type: 'string', index: 'analyzed' }
-              }
-            }
-          }
-        },
-        indexName = 'myIndex',
         func = function (ops) {
           return ops;
-        },
-        expectedResp = [
-          [{
-            ops: batchOps,
-            mapping: {
-              dynamic: false,
-              properties: {
-                propertyName: { type: 'string', index: 'analyzed' }
-              }
-            },
-            typeName: 'general'
-          }]
-        ];
+        };
 
       it('returns an operation without its refs', function () {
-        return fn(batchOps, mappings, indexName, func)
+        return fn(batchOps, 'myIndex', func)
           .then(function (resp) {
-            expect(resp).to.deep.equal(expectedResp);
+            expect(resp).to.deep.equal(batchOps);
           });
       });
     });

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -78,11 +78,10 @@ function existsIndex(index) {
  * in the index
  *
  * @param  {string} index
- * @param  {string} type
  * @param  {string} id
  * @return {Promise}
  */
-function existsDocument(index, type, id) {
+function existsDocument(index, id) {
   if (!id) {
     let err = new Error('Cannot check if document exists without an id');
 
@@ -139,11 +138,10 @@ function existsAlias(name) {
  * Create an Elasticsearch mapping
  *
  * @param {string} index
- * @param {string} type
  * @param {object} mapping
  * @returns {Promise}
  */
-function initMapping(index, type, mapping) {
+function initMapping(index, mapping) {
   return client.indices.putMapping({
     index: index,
     type: FIXED_TYPE,
@@ -207,7 +205,7 @@ function addSettings(index, settings) {
  * @param {type} type
  * @returns {Promise}
  */
-function existsMapping(index, type) {
+function existsMapping(index) {
   return client.indices.getMapping({
     index: index,
     type: FIXED_TYPE
@@ -218,19 +216,18 @@ function existsMapping(index, type) {
  * Create an Elasticsearch mapping if one doesn't exist
  *
  * @param {string} index
- * @param {string} type
  * @param {object} mapping
  * @returns {Promise}
  */
-function createMappingIfNone(index, type, mapping) {
-  return module.exports.existsMapping(index, type)
+function createMappingIfNone(index, mapping) {
+  return module.exports.existsMapping(index)
     .then(function (result) {
-      let getMapping = _.get(result, `${index}.mappings.${type}`);
+      let getMapping = _.get(result, `${index}.mappings.${FIXED_TYPE}`);
 
       if (!_.size(getMapping)) {
         log('warn', `Mapping is missing for ${index}!`);
 
-        return module.exports.initMapping(index, type, mapping)
+        return module.exports.initMapping(index, mapping)
           .then(function (result) {
             log('info', `Creating mapping ${index}: ${result}`);
           }).catch(function (error) {
@@ -299,11 +296,10 @@ function createAliasIfNone(index, prefix) {
  * Convert Redis batch operations to Elasticsearch batch operations
  *
  * @param {string} index
- * @param {string} type
  * @param {Array} ops
  * @returns {Array}
  */
-function convertRedisBatchtoElasticBatch(index, type, ops) {
+function convertRedisBatchtoElasticBatch(index, ops) {
   let bulkOps = [];
 
   _.each(ops, function (op) {
@@ -341,7 +337,7 @@ function convertRedisBatchtoElasticBatch(index, type, ops) {
  * @param {string} type
  * @returns {Promise}
  */
-function query(index, query, type) {
+function query(index, query) {
   return client.search({
     index: index,
     type: FIXED_TYPE,
@@ -358,12 +354,11 @@ function query(index, query, type) {
  * Index an Elasticsearch document
  *
  * @param {string} index
- * @param {string} type
  * @param {string} ref, e.g. 'localhost.dev.nymag.biz/scienceofus/components/article/instances/section-test'
  * @param {object} source
  * @returns {Promise}
  */
-function put(index, type, ref, source) {
+function put(index, ref, source) {
   return client.index({
     index: index,
     type: FIXED_TYPE,
@@ -381,11 +376,10 @@ function put(index, type, ref, source) {
  * Delete an Elasticsearch document
  *
  * @param {string} index
- * @param {string} type
  * @param {string} ref, e.g. 'localhost.dev.nymag.biz/scienceofus/components/article/instances/section-test'
  * @returns {Promise}
  */
-function del(index, type, ref) {
+function del(index, ref) {
   return client.delete({
     index: index,
     type: FIXED_TYPE,
@@ -463,7 +457,7 @@ function validateIndices(mappings, settings, prefix) {
     .then(function () {
       return bluebird.all(_.reduce(mappings, function (acc, types, index) {
         // Push the Promise of creating the mapping into the accumulator
-        acc.push(module.exports.createMappingIfNone(createIndexName(index, prefix), FIXED_TYPE, types[FIXED_TYPE]));
+        acc.push(module.exports.createMappingIfNone(createIndexName(index, prefix), types[FIXED_TYPE]));
         return acc;
       }, []));
     });
@@ -474,11 +468,10 @@ function validateIndices(mappings, settings, prefix) {
  * index with a matching `id`
  *
  * @param  {string} index
- * @param  {string} type
  * @param  {string} id
  * @return {Promise}
  */
-function getDocument(index, type, id) {
+function getDocument(index, id) {
   if (!id) {
     let err = new Error('Cannot get a document without the id');
 
@@ -497,14 +490,13 @@ function getDocument(index, type, id) {
  * Update a document in an elastic search index.
  *
  * @param  {string} index
- * @param  {string} type
  * @param  {string} id
  * @param  {object} data
  * @param  {Boolean} refresh
  * @param  {Boolean} upsert
  * @return {Promise}
  */
-function update(index, type, id, data, refresh = false, upsert = false) { // eslint-disable-line max-params
+function update(index, id, data, refresh = false, upsert = false) { // eslint-disable-line max-params
   if (!data) {
     let err = new Error('Updating an Elastic document requires a data object');
 

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -10,7 +10,8 @@ const elastic = require('elasticsearch'),
     maxSockets: 500,
     apiVersion: '2.4',
     defer: () => bluebird.defer()
-  };
+  },
+  FIXED_TYPE = 'general';
 var log = require('./log').setup({file: __filename}),
   client; // Reference to the ES client
 
@@ -91,7 +92,7 @@ function existsDocument(index, type, id) {
 
   return client.exists({
     index: index,
-    type: type,
+    type: FIXED_TYPE,
     id: id
   });
 }
@@ -145,14 +146,14 @@ function existsAlias(name) {
 function initMapping(index, type, mapping) {
   return client.indices.putMapping({
     index: index,
-    type: type,
+    type: FIXED_TYPE,
     body: mapping
   }).then(function () {
     log('debug', `Successfully created a mapping for ${index}`);
     return bluebird.resolve(index);
   })
     .catch(function (error) {
-      log('error', error);
+      log('error', error.message);
       return bluebird.reject(error);
     });
 }
@@ -172,7 +173,7 @@ function putSettings(index, settings) {
     log('debug', `Successfully put settings for ${index}`);
     return bluebird.resolve(index);
   }).catch(function (error) {
-    log('error', error);
+    log('error', error.message);
     return bluebird.reject(error);
   });
 }
@@ -209,7 +210,7 @@ function addSettings(index, settings) {
 function existsMapping(index, type) {
   return client.indices.getMapping({
     index: index,
-    type: type
+    type: FIXED_TYPE
   });
 }
 
@@ -224,16 +225,16 @@ function existsMapping(index, type) {
 function createMappingIfNone(index, type, mapping) {
   return module.exports.existsMapping(index, type)
     .then(function (result) {
-      let getMapping = _.get(result, index + '.mappings.' + type);
+      let getMapping = _.get(result, `${index}.mappings.${type}`);
 
       if (!_.size(getMapping)) {
         log('warn', `Mapping is missing for ${index}!`);
 
         return module.exports.initMapping(index, type, mapping)
           .then(function (result) {
-            log('info', `Creating mapping ${index} ${type}: ${result}`);
+            log('info', `Creating mapping ${index}: ${result}`);
           }).catch(function (error) {
-            log('error', error.stack);
+            log('error', error.message, { stack: error.stack });
           });
       } else {
         log('debug', `Mapping found for ${index}`);
@@ -315,7 +316,7 @@ function convertRedisBatchtoElasticBatch(index, type, ops) {
     } else if (op.type === 'put') {
       let indexOp = {
         _index: index,
-        _type: type
+        _type: FIXED_TYPE
       };
 
       // key is optional; if missing, an id will be generated that is unique across all shards
@@ -342,7 +343,7 @@ function convertRedisBatchtoElasticBatch(index, type, ops) {
 function query(index, query, type) {
   return client.search({
     index: index,
-    type: type,
+    type: FIXED_TYPE,
     body: query
   })
     .catch(function (error) {
@@ -364,7 +365,7 @@ function query(index, query, type) {
 function put(index, type, ref, source) {
   return client.index({
     index: index,
-    type: type,
+    type: FIXED_TYPE,
     id: ref,
     body: source
   }).then(function (resp) {
@@ -386,7 +387,7 @@ function put(index, type, ref, source) {
 function del(index, type, ref) {
   return client.delete({
     index: index,
-    type: type,
+    type: FIXED_TYPE,
     id: ref
   }).then(function (resp) {
     log('debug', JSON.stringify(resp));
@@ -460,9 +461,11 @@ function validateIndices(mappings, settings, prefix) {
     })
     .then(function () {
       return bluebird.all(_.reduce(mappings, function (list, types, index) {
-        return list.concat(_.map(types, function (mapping, type) {
-          return module.exports.createMappingIfNone(createIndexName(index, prefix), type, mapping);
-        }));
+        console.log('!', mappings);
+        // console.log('\n\n', types, '\n\n');
+        // return list.concat(_.map(types, function (mapping, type) {
+        return module.exports.createMappingIfNone(createIndexName(index, prefix), FIXED_TYPE, mapping);
+        // }));
       }, []));
     });
 }
@@ -486,7 +489,7 @@ function getDocument(index, type, id) {
 
   return client.get({
     index: index,
-    type: type,
+    type: FIXED_TYPE,
     id: id
   });
 }
@@ -511,7 +514,10 @@ function update(index, type, id, data, refresh = false, upsert = false) { // esl
   }
 
   return client.update({
-    index, type, id, refresh,
+    index,
+    type: FIXED_TYPE,
+    id,
+    refresh,
     body: {
       doc: data,
       doc_as_upsert: upsert

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -519,7 +519,7 @@ function update(index, id, data, refresh = false, upsert = false) { // eslint-di
 
 
 function getInstance() {
-  return module.exports.client || client;
+  return module.exports.client;
 }
 
 module.exports.setup = setup;

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -239,7 +239,8 @@ function createMappingIfNone(index, type, mapping) {
       } else {
         log('debug', `Mapping found for ${index}`);
       }
-    });
+    })
+    .catch(logError);
 }
 
 /**
@@ -460,12 +461,10 @@ function validateIndices(mappings, settings, prefix) {
       }));
     })
     .then(function () {
-      return bluebird.all(_.reduce(mappings, function (list, types, index) {
-        console.log('!', mappings);
-        // console.log('\n\n', types, '\n\n');
-        // return list.concat(_.map(types, function (mapping, type) {
-        return module.exports.createMappingIfNone(createIndexName(index, prefix), FIXED_TYPE, mapping);
-        // }));
+      return bluebird.all(_.reduce(mappings, function (acc, types, index) {
+        // Push the Promise of creating the mapping into the accumulator
+        acc.push(module.exports.createMappingIfNone(createIndexName(index, prefix), FIXED_TYPE, types[FIXED_TYPE]));
+        return acc;
       }, []));
     });
 }

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -214,9 +214,11 @@ describe(_.startCase(filename), function () {
     var fn = lib[this.title];
 
     it('calls existsMapping successfully', function () {
-      sandbox.stub(lib, 'existsMapping').returns(Promise.resolve({ 'index.mappings.type': [1, 2, 3] }));
+      sandbox.stub(lib, 'existsMapping').returns(Promise.resolve({
+        index: { mappings: { general: { properties: {} } } }
+      }));
       sandbox.stub(lib, 'initMapping').returns(Promise.resolve(true));
-      return fn('index', 'type', 'mapping')
+      return fn('index', 'mapping')
         .then(function () {
           expect(lib.existsMapping.calledOnce).to.be.true;
         });
@@ -225,7 +227,7 @@ describe(_.startCase(filename), function () {
     it('calls initMapping successfully', function () {
       sandbox.stub(lib, 'existsMapping').returns(Promise.resolve());
       sandbox.stub(lib, 'initMapping').returns(Promise.resolve(true));
-      return fn('index', 'type', 'mapping')
+      return fn('index', 'mapping')
         .then(function () {
           expect(lib.initMapping.called).to.be.true;
         });
@@ -234,9 +236,21 @@ describe(_.startCase(filename), function () {
     it('catches on initMapping if there is a rejection', function () {
       sandbox.stub(lib, 'existsMapping').returns(Promise.resolve());
       sandbox.stub(lib, 'initMapping').returns(Promise.reject(false));
-      return fn('index', 'type', 'mapping')
+      return fn('index', 'mapping')
         .then(function () {
           expect(lib.initMapping.called).to.be.true;
+        });
+    });
+
+    it('logs if the mapping is already found', function () {
+      sandbox.stub(lib, 'existsMapping').returns(Promise.resolve({
+        index: { mappings: { general: { properties: {} } } }
+      }));
+      sandbox.stub(lib, 'initMapping');
+      return fn('index', 'mapping')
+        .then(function () {
+          sinon.assert.notCalled(lib.initMapping);
+          sinon.assert.calledWith(logFn, 'debug');
         });
     });
   });

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -305,7 +305,7 @@ describe(_.startCase(filename), function () {
     it('rejects if no id is provided', function () {
       const errMsg = 'Cannot check if document exists without an id';
 
-      return fn('pages', 'general')
+      return fn('pages')
         .catch(err => {
           sinon.assert.calledWith(logFn, 'error', errMsg);
           expect(err.message).to.equal(errMsg);
@@ -314,7 +314,7 @@ describe(_.startCase(filename), function () {
 
     it('calls the exists method provided by the ES client', function () {
       client.exists.returns(Promise.resolve('ES Client `exists` called'));
-      return fn('pages', 'general', 'site/pages/foo')
+      return fn('pages', 'site/pages/foo')
         .then(function () {
           expect(client.exists.calledOnce).to.be.true;
         });
@@ -327,7 +327,7 @@ describe(_.startCase(filename), function () {
     it('rejects if no id is provided', function () {
       const errMsg = 'Cannot get a document without the id';
 
-      return fn('pages', 'general')
+      return fn('pages')
         .catch(err => {
           sinon.assert.calledWith(logFn, 'error', errMsg);
           expect(err.message).to.equal(errMsg);
@@ -336,7 +336,7 @@ describe(_.startCase(filename), function () {
 
     it('calls the exists method provided by the ES client', function () {
       client.get.returns(Promise.resolve('ES Client `get` called'));
-      return fn('pages', 'general', 'site/pages/foo')
+      return fn('pages', 'site/pages/foo')
         .then(function () {
           expect(client.get.calledOnce).to.be.true;
         });
@@ -349,7 +349,7 @@ describe(_.startCase(filename), function () {
     it('rejects if no data is provided', function () {
       const errMsg = 'Updating an Elastic document requires a data object';
 
-      return fn('pages', 'general', 'site/pages/foo')
+      return fn('pages', 'site/pages/foo')
         .catch(err => {
           sinon.assert.calledWith(logFn, 'error', errMsg);
           expect(err.message).to.equal(errMsg);
@@ -358,7 +358,7 @@ describe(_.startCase(filename), function () {
 
     it('calls the update method provided by the ES client', function () {
       client.update.returns(Promise.resolve('ES Client `update` called'));
-      return fn('pages', 'general', 'site/pages/foo', {})
+      return fn('pages', 'site/pages/foo', {})
         .then(function () {
           expect(client.update.calledOnce).to.be.true;
         });
@@ -366,7 +366,7 @@ describe(_.startCase(filename), function () {
 
     it('calls the update method provided by the ES client with refresh param', function () {
       client.update.returns(Promise.resolve('ES Client `update` called'));
-      return fn('pages', 'general', 'site/pages/foo', {}, true)
+      return fn('pages', 'site/pages/foo', {}, true)
         .then(function () {
           sinon.assert.calledOnce(client.update);
         });
@@ -531,7 +531,7 @@ describe(_.startCase(filename), function () {
       const ops = [{ value: 'value' }],
         errMsg = 'op.value cannot be a string';
 
-      fn('index', 'type', ops);
+      fn('index', ops);
       sinon.assert.calledWith(logFn, 'error', errMsg);
       expect(logFn.args[0][2].op).to.eql(ops[0]);
     });
@@ -539,19 +539,19 @@ describe(_.startCase(filename), function () {
     it('returns an array of ops if type property equals "put"', function () {
       var ops = [{ value: {}, type: 'put' }];
 
-      expect(fn('index', 'type', ops)).to.deep.equal([{ index: { _index: 'index', _type: 'type' } }, {}]);
+      expect(fn('index', ops)).to.deep.equal([{ index: { _index: 'index', _type: 'general' } }, {}]);
     });
 
     it('assigns a "key" property if one is defined in the op', function () {
       var ops = [{ value: {}, type: 'put', key: 'key' }];
 
-      expect(fn('index', 'type', ops)).to.deep.equal([{ index: { _id: 'key', _index: 'index', _type: 'type' } }, {}]);
+      expect(fn('index', ops)).to.deep.equal([{ index: { _id: 'key', _index: 'index', _type: 'general' } }, {}]);
     });
 
     it('assigns a "key" property if one is defined in the op', function () {
       var ops = [{ value: {}, type: 'get', key: 'key' }];
 
-      expect(fn('index', 'type', ops)).to.deep.equal([]);
+      expect(fn('index', ops)).to.deep.equal([]);
     });
   });
 

--- a/lib/services/log.test.js
+++ b/lib/services/log.test.js
@@ -2,7 +2,6 @@
 const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
-  expect = require('chai').expect,
   sinon = require('sinon'),
   clayLog = require('clay-log');
 

--- a/lib/users-list.js
+++ b/lib/users-list.js
@@ -34,7 +34,7 @@ function updateUserList(ops) {
   // Grab the unique key
   key = userOp.key.replace(USER_STRING, '');
 
-  return elastic.update(USERS_INDEX, 'general', key, userData, false, true)
+  return elastic.update(USERS_INDEX, key, userData, false, true)
     .then(function (result) {
       log('debug', `User data updates for user: ${result._id}`);
       return result;
@@ -63,7 +63,7 @@ function testForUser(ops) {
  */
 function removeUsers(ops) {
   _.map(ops, op => {
-    elastic.del(USERS_INDEX, 'general', op.key.replace(USER_STRING, ''))
+    elastic.del(USERS_INDEX, op.key.replace(USER_STRING, ''))
       .then(resp => {
         log('debug', `User data removed from index for user: ${resp._id}`);
       });

--- a/lib/users-list.test.js
+++ b/lib/users-list.test.js
@@ -65,7 +65,7 @@ describe(_.startCase(filename), function () {
       elastic.update.returns(Promise.resolve({_id: 'cool person'}));
       return fn(userOps).then(function () {
         sinon.assert.calledOnce(elastic.update);
-        sinon.assert.calledWith(elastic.update, 'users', 'general', 'someEncodedString');
+        sinon.assert.calledWith(elastic.update, 'users', 'someEncodedString');
       });
     });
 
@@ -73,7 +73,7 @@ describe(_.startCase(filename), function () {
       elastic.update.returns(Promise.resolve({_id: 'cool person'}));
       return fn(userOps).then(function () {
         sinon.assert.calledOnce(elastic.update);
-        sinon.assert.calledWith(elastic.update, 'users', 'general', 'someEncodedString');
+        sinon.assert.calledWith(elastic.update, 'users', 'someEncodedString');
       });
     });
 


### PR DESCRIPTION
Mapping types are roadmapped to be removed from Elastic: https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html

To get ahead of that, let's remove all accommodations for types and only allow a mapping to have one `type`: `general`.

With that in place...

- Updated `applyOpFilters` to not require a `mappings` argument and return only the ops it transforms
- Updated `normalizeOpValuesWithMapping` to require an index name, not a whole object of mappings
- Added some logging
- Removed the `type` arg from functions calling the Elastic client.