### PR TITLE
removing a bad \general\

### DIFF
--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -130,7 +130,7 @@ function constructPageData(ops) {
  */
 function pageExists(ops) {
   return bluebird.all(_.map(ops, function (op) {
-    return elastic.existsDocument(PAGES_INDEX, 'general', pageUriFromKey(op.key));
+    return elastic.existsDocument(PAGES_INDEX, pageUriFromKey(op.key));
   }));
 }
 
@@ -158,7 +158,6 @@ function updateExistingPageData(ops) {
         updateData.scheduledTime = scheduledTime;
         updateData.url = data.url ? data.url : source.url;
         updateData.publishTime = published ? new Date() : source.publishTime;
-
         return module.exports.updatePageData(resp._id, updateData);
       });
   }));


### PR DESCRIPTION
Bug Fix: don't pass in the type. that was deprecated.