### PR TITLE
add validation for @scheduled

### DIFF
--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -84,8 +84,6 @@ function streamUpdate({ key, value }) { // update the page
 function markPagePublished(page) {
   var { url, customUrl } = JSON.parse(page.value);
 
-  console.log('page', page);
-
   return existsPage(page)
     .flatMap(getPageById)
     .map(function ({ _id, _source }) {

--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -115,6 +115,20 @@ function markScheduled({ key, value }) {
 }
 
 /**
+ * Filter out pages that are neither new nor scheduled
+ *
+ * @param  {Object} pageOp
+ * @return {boolean}
+ */
+function isScheduledOrNew(pageOp) {
+  return function (resp) {
+    var isScheduled = pageOp.key.indexOf('@schedule') > -1;
+
+    return isScheduled || !resp;
+  };
+}
+
+/**
  * Either mark a page as scheduled of make a new document
  *
  * @param  {Object} pageOp
@@ -122,10 +136,9 @@ function markScheduled({ key, value }) {
  */
 function scheduledOrNew(pageOp) {
   return existsPage(pageOp)
+    .filter(isScheduledOrNew(pageOp))
     .flatMap(function (resp) {
-      var isScheduled = pageOp.key.indexOf('@schedule') > -1;
-
-      return resp && isScheduled ? module.exports.markScheduled(pageOp) : module.exports.newPageData(pageOp);
+      return resp ? module.exports.markScheduled(pageOp) : module.exports.newPageData(pageOp);
     });
 }
 

--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -118,13 +118,11 @@ function markScheduled({ key, value }) {
  * Filter out pages that are neither new nor scheduled
  *
  * @param  {Object} pageOp
- * @return {boolean}
+ * @return {Function}
  */
 function isScheduledOrNew(pageOp) {
   return function (resp) {
-    var isScheduled = pageOp.key.indexOf('@schedule') > -1;
-
-    return isScheduled || !resp;
+    return pageOp.key.indexOf('@schedule') > -1 || !resp;
   };
 }
 

--- a/lib/page-list.js
+++ b/lib/page-list.js
@@ -84,6 +84,8 @@ function streamUpdate({ key, value }) { // update the page
 function markPagePublished(page) {
   var { url, customUrl } = JSON.parse(page.value);
 
+  console.log('page', page);
+
   return existsPage(page)
     .flatMap(getPageById)
     .map(function ({ _id, _source }) {
@@ -123,7 +125,9 @@ function markScheduled({ key, value }) {
 function scheduledOrNew(pageOp) {
   return existsPage(pageOp)
     .flatMap(function (resp) {
-      return resp ? module.exports.markScheduled(pageOp) : module.exports.newPageData(pageOp);
+      var isScheduled = pageOp.key.indexOf('@schedule') > -1;
+
+      return resp && isScheduled ? module.exports.markScheduled(pageOp) : module.exports.newPageData(pageOp);
     });
 }
 

--- a/lib/page-list.test.js
+++ b/lib/page-list.test.js
@@ -329,18 +329,18 @@ describe(_.startCase(filename), function () {
   describe('scheduledOrNew', function () {
     const fn = lib[this.title];
 
-    it('calls `markScheduled` if the page exists', function (done) {
+    it('calls `markScheduled` if the page exists and has been scheduled', function (done) {
       search.existsDocument.returns(Promise.resolve(true));
       sandbox.stub(lib, 'markScheduled').returns(h.of('cool'));
 
-      fn({ key: 'somePage' })
+      fn({ key: 'somePage@scheduled' })
         .each(function () {
           sinon.assert.calledOnce(lib.markScheduled);
         })
         .done(() => done());
     });
 
-    it('calls `newPageData` if the page exists', function (done) {
+    it('calls `newPageData` if the page does not exist', function (done) {
       search.existsDocument.returns(Promise.resolve(false));
       sandbox.stub(lib, 'newPageData').returns(h.of('cool'));
 


### PR DESCRIPTION
Small patch for a bug where`clay import --page` yields an error when the imported page is incorrectly handled as `scheduled`. This routinely occurs when the import command is run on a page that has already been imported.