### PR TITLE
_pagelist shouldn't swallow errors

### DIFF
--- a/lib/page-list/utils.js
+++ b/lib/page-list/utils.js
@@ -71,6 +71,14 @@ function updatePage(uri, data) {
       return result;
     }).catch(function (error) {
       log('error', error);
+      if (error.message && _.includes(error.message, 'strict_dynamic_mapping_exception')) {
+        // trying to save properties that aren't mapped
+        error.code = 400;
+      } else {
+        // some other error
+        error.code = 500;
+      }
+      return Promise.reject(error);
     });
 }
 

--- a/lib/page-list/utils.test.js
+++ b/lib/page-list/utils.test.js
@@ -90,7 +90,14 @@ describe(`Page List: ${_.startCase(filename)}:`, function () {
 
     it('logs error if elastic update fails', function () {
       elastic.update.returns(Promise.reject(new Error('nope')));
-      return fn(uri, {}).then(function () {
+      return fn(uri, {}).catch(function () {
+        expect(logFn.calledWith('error')).to.equal(true);
+      });
+    });
+
+    it('logs client error if elastic update fails with strict mapping exception', function () {
+      elastic.update.returns(Promise.reject(new Error('strict_dynamic_mapping_exception: foo is bad')));
+      return fn(uri, {}).catch(function () {
         expect(logFn.calledWith('error')).to.equal(true);
       });
     });

--- a/lib/services/responses.js
+++ b/lib/services/responses.js
@@ -48,7 +48,11 @@ function getAuthUrl(site) {
  */
 function handleError(res) {
   return function (err) {
-    res.send(err.stack);
+    if (err.code) {
+      res.status(err.code).send(err.stack);
+    } else {
+      res.send(err.stack);
+    }
   };
 }
 

--- a/lib/services/responses.test.js
+++ b/lib/services/responses.test.js
@@ -45,7 +45,8 @@ describe(_.startCase(filename), function () {
       func = sinon.stub(),
       res = {
         json: _.noop,
-        send: _.noop
+        send: _.noop,
+        status: _.noop
       };
 
     it('sends back JSON when the function resolves', function () {
@@ -64,6 +65,17 @@ describe(_.startCase(filename), function () {
       sandbox.stub(res, 'send');
       fn(func, res);
       expect(res.send.calledWith(resolution.stack));
+    });
+
+    it('errors with custom code', function () {
+      const resolution = new Error('An error occured');
+
+      resolution.code = 400;
+      func.returns(Promise.reject(resolution));
+      sandbox.stub(res, 'send');
+      sandbox.stub(res, 'status').returns(res);
+      fn(func, res);
+      expect(res.status.calledWith(400));
     });
   });
 


### PR DESCRIPTION
Instead of swallowing errors, send them back to the client

* also set status to `400` if it's a strict mapping exception
* also set status to `500` if it's a weird code error