### PR TITLE
Fixes _search error handling

### DIFF
--- a/lib/routes/_search.js
+++ b/lib/routes/_search.js
@@ -4,7 +4,8 @@ const _ = require('lodash'),
   elastic = require('../services/elastic'),
   helpers = require('../services/elastic-helpers'),
   responses = require('../services/responses'),
-  log = require('../services/log').setup({ file: __filename });
+  log = require('../services/log').setup({ file: __filename }),
+  bluebird = require('bluebird');
 
 /**
  * Add the prefix to any index specified

--- a/lib/routes/_search.js
+++ b/lib/routes/_search.js
@@ -4,8 +4,7 @@ const _ = require('lodash'),
   elastic = require('../services/elastic'),
   helpers = require('../services/elastic-helpers'),
   responses = require('../services/responses'),
-  log = require('../services/log').setup({ file: __filename }),
-  bluebird = require('bluebird');
+  log = require('../services/log').setup({ file: __filename });
 
 /**
  * Add the prefix to any index specified
@@ -18,7 +17,7 @@ function decorateWithPrefix(queryObj) {
     let err = new Error('An index property is required to search');
 
     log('error', err.message, { stack: err.stack });
-    return bluebird.reject(err);
+    throw err;
   }
 
   queryObj.index = helpers.indexWithPrefix(queryObj.index);


### PR DESCRIPTION
A function in `_search` is returning a bluebird promise rejection under a condition, but bluebird is not imported and the function should be throwing an error instead.