### PR TITLE
Sitemaps: Parse year query param as number, fix tests

### DIFF
--- a/lib/routes/_sitemaps.js
+++ b/lib/routes/_sitemaps.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const sitemaps = require('../services/sitemaps');
+const sitemaps = require('../services/sitemaps'),
+  _ = require('lodash');
 
 function routes(router) {
   if (sitemaps.sitemapsEnabled()) {
@@ -13,7 +14,13 @@ function routes(router) {
 }
 
 function textSitemap(req, res) {
-  const year = req.query.year || new Date().getFullYear();
+  const year = req.query.year ?
+    parseInt(req.query.year, 10) :
+    new Date().getFullYear();
+
+  if (!_.isFinite(year)) {
+    return res.status(500).send('"year" must be a number');
+  }
 
   return sitemaps.streamEntries(res.locals.site.slug, year)
     .map(entry => `${entry.url}\n`)
@@ -21,7 +28,13 @@ function textSitemap(req, res) {
 }
 
 function xmlSitemap(req, res) {
-  const year = req.query.year || new Date().getFullYear();
+  const year = req.query.year ?
+    parseInt(req.query.year, 10) :
+    new Date().getFullYear();
+
+  if (!_.isFinite(year)) {
+    return res.status(500).send('"year" must be a number');
+  }
 
   res.write(sitemaps.preludes.standard);
   return sitemaps.streamEntries(res.locals.site.slug, year)

--- a/lib/routes/_sitemaps.test.js
+++ b/lib/routes/_sitemaps.test.js
@@ -36,13 +36,13 @@ describe(_.startCase(filename), function () {
     it ('renders urls at /sitemap.txt if sitemaps are enabled', function () {
       sitemaps.sitemapsEnabled.returns(true);
       sitemaps.streamEntries
-        .withArgs('foo', '2018')
+        .withArgs('foo', 2014)
         .returns(h([{url: 'a'}, {url: 'b'}]));
       lib(app);
 
       return request(app)
         .get('/sitemap.txt')
-        .query({year: '2018'})
+        .query({year: 2014})
         .expect(200)
         .then(response => {
           expect(response.text).to.equal('a\nb\n');
@@ -67,7 +67,7 @@ describe(_.startCase(filename), function () {
     it ('renders standard xml elements at /sitemap.xml if sitemaps are enabled', function () {
       sitemaps.sitemapsEnabled.returns(true);
       sitemaps.streamEntries
-        .withArgs('foo', '2018')
+        .withArgs('foo', 2014)
         .returns(h([{url: 'a'}, {url: 'b'}]));
       sitemaps.renderEntry
         .onFirstCall().returns('a')
@@ -76,7 +76,7 @@ describe(_.startCase(filename), function () {
 
       return request(app)
         .get('/sitemap.xml')
-        .query({year: '2018'})
+        .query({year: 2014})
         .expect(200)
         .then(response => {
           expect(response.text).to.equal(`${sitemaps.preludes.standard}ab</urlset>`);
@@ -137,7 +137,7 @@ describe(_.startCase(filename), function () {
 
     it ('404s on /news.xml if sitemaps are not enabled', function () {
       sitemaps.sitemapsEnabled.returns(false);
-
+      lib(app);
       return request(app)
         .get('/news.xml')
         .expect(404);
@@ -146,11 +146,34 @@ describe(_.startCase(filename), function () {
     it ('404s on /news.xml if news sitemap does not exist', function () {
       sitemaps.sitemapsEnabled.returns(true);
       sitemaps.newsSitemapExists.returns(false);
-
+      lib(app);
       return request(app)
-        .get('/sitemap.xml')
+        .get('/news.xml')
         .expect(404);
     });
-  });
 
+    it ('500s on /sitemap.txt if "year" query param cannot be parsed as a number', function () {
+      sitemaps.sitemapsEnabled.returns(true);
+      lib(app);
+      return request(app)
+        .get('/sitemap.txt')
+        .query({year: 'a'})
+        .expect(500)
+        .then(response => {
+          expect(response.text).to.equal('"year" must be a number');
+        });
+    });
+
+    it ('500s on /sitemap.xml if "year" query param cannot be parsed as a number', function () {
+      sitemaps.sitemapsEnabled.returns(true);
+      lib(app);
+      return request(app)
+        .get('/sitemap.xml')
+        .query({year: 'a'})
+        .expect(500)
+        .then(response => {
+          expect(response.text).to.equal('"year" must be a number');
+        });
+    });
+  });
 });


### PR DESCRIPTION
* makes sitemaps router parse `req.query.year` as a number before passing it to the sitemaps service
* changes tests to reflect this
* fixes unrelated sitemaps tests in which router was not being mounted to test app