### PR TITLE
Index Settings

### DIFF
--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -47,12 +47,13 @@ function healthCheck(currentClient) {
  * Create an Elasticsearch index
  *
  * @param {string} index
+ * @param {object} settings
  * @returns {Promise}
  */
-function initIndex(index) {
+function initIndex(index, settings) {
   return client.indices.create({
     index: index,
-    body: {}
+    body: settings || {}
   }).then(function () {
     log('debug', `Successfully created ${index}`);
   })
@@ -178,27 +179,6 @@ function putSettings(index, settings) {
 }
 
 /**
- * Add settings to an index if it exists
- *
- * @param {String} index
- * @param {Object} settings
- * @return {Promise}
- */
-function addSettings(index, settings) {
-  return module.exports.existsIndex(index)
-    .then(function (exists) {
-      if (exists) {
-        return client.indices.close({index})
-          .then(() => module.exports.putSettings(index, settings))
-          .then(() => client.indices.open({index}));
-      } else {
-        log('warn', `Could not put settings for index ${index} because it does not exist`);
-        return bluebird.resolve();
-      }
-    });
-}
-
-/**
  * Check if an Elasticsearch mapping exists
  * Note: An empty mapping can still exist
  *
@@ -247,11 +227,11 @@ function createMappingIfNone(index, mapping) {
  * @param {string} index
  * @returns {Promise}
  */
-function createIndexIfNone(index) {
+function createIndexIfNone(index, settings) {
   return existsIndex(index)
     .then(function (exists) {
       if (!exists) {
-        return module.exports.initIndex(index)
+        return module.exports.initIndex(index, settings)
           .then(function () {
             log('info', `Creating Elasticsearch index: ${index}`);
           })
@@ -443,18 +423,10 @@ function setup(overrideClient) {
  */
 function validateIndices(mappings, settings, prefix) {
   return bluebird.all(_.map(Object.keys(mappings), function (index) {
-    return module.exports.createIndexIfNone(createIndexName(index, prefix)).then(function () {
+    return module.exports.createIndexIfNone(createIndexName(index, prefix), settings[index]).then(function () {
       return module.exports.createAliasIfNone(index, prefix);
     });
   }))
-    .then(function () {
-      return bluebird.all(_.map(mappings, function (list, index) {
-        if (settings && settings[index]) {
-          return module.exports.addSettings(createIndexName(index, prefix), settings[index]);
-        }
-        return bluebird.resolve();
-      }));
-    })
     .then(function () {
       return bluebird.all(_.reduce(mappings, function (acc, types, index) {
         // Push the Promise of creating the mapping into the accumulator
@@ -538,7 +510,6 @@ module.exports.existsDocument = existsDocument;
 module.exports.initMapping = initMapping;
 module.exports.existsMapping = existsMapping;
 module.exports.putSettings = putSettings;
-module.exports.addSettings = addSettings;
 module.exports.createMappingIfNone = createMappingIfNone;
 module.exports.convertRedisBatchtoElasticBatch = convertRedisBatchtoElasticBatch;
 module.exports.getDocument = getDocument;

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -416,7 +416,7 @@ describe(_.startCase(filename), function () {
       lib.createAliasIfNone.returns(bluebird.resolve('alias'));
       lib.createMappingIfNone.returns(bluebird.resolve('mapping'));
 
-      return fn(mapping)
+      return fn(mapping, {})
         .then(function () {
           sinon.assert.calledOnce(lib.createIndexIfNone);
           sinon.assert.calledOnce(lib.createAliasIfNone);
@@ -424,20 +424,21 @@ describe(_.startCase(filename), function () {
         });
     });
 
-    it('calls tries to add settings if they exist', function () {
-      sandbox.stub(lib, 'createIndexIfNone');
-      sandbox.stub(lib, 'createAliasIfNone');
-      sandbox.stub(lib, 'createMappingIfNone');
-      sandbox.stub(lib, 'addSettings');
-      lib.createIndexIfNone.returns(bluebird.resolve('index'));
-      lib.createAliasIfNone.returns(bluebird.resolve('alias'));
-      lib.createMappingIfNone.returns(bluebird.resolve('mapping'));
-
-      return fn(mapping, settings)
-        .then(function () {
-          sinon.assert.calledOnce(lib.addSettings);
-        });
-    });
+    // it('calls tries to add settings if they exist', function () {
+    //   sandbox.stub(lib, 'createIndexIfNone');
+    //   sandbox.stub(lib, 'createAliasIfNone');
+    //   sandbox.stub(lib, 'createMappingIfNone');
+    //   // sandbox.stub(lib, 'addSettings');
+    //   lib.createIndexIfNone.returns(bluebird.resolve('index'));
+    //   lib.createAliasIfNone.returns(bluebird.resolve('alias'));
+    //   lib.createMappingIfNone.returns(bluebird.resolve('mapping'));
+    //
+    //   return fn(mapping, settings)
+    //     .then(function () {
+    //
+    //       // sinon.assert.calledOnce(lib.addSettings);
+    //     });
+    // });
   });
 
   describe('existsAlias', function () {
@@ -610,32 +611,32 @@ describe(_.startCase(filename), function () {
     });
   });
 
-  describe('addSettings', function () {
-    const fn = lib[this.title];
-
-
-    it('runs a `putSettings` if an index exists', function () {
-      client.indices.close.returns(Promise.resolve());
-      client.indices.open.returns(Promise.resolve());
-      sandbox.stub(lib, 'existsIndex').returns(bluebird.resolve(true));
-      sandbox.stub(lib, 'putSettings');
-
-      return fn('pages', {})
-        .then(function () {
-          sinon.assert.calledOnce(lib.putSettings);
-        });
-    });
-
-    it('runs nothing if an index does not exists', function () {
-      sandbox.stub(lib, 'existsIndex').returns(bluebird.resolve(false));
-      sandbox.stub(lib, 'putSettings');
-
-      return fn('pages', {})
-        .then(function () {
-          sinon.assert.notCalled(lib.putSettings);
-        });
-    });
-  });
+  // describe('addSettings', function () {
+  //   const fn = lib[this.title];
+  //
+  //
+  //   it('runs a `putSettings` if an index exists', function () {
+  //     client.indices.close.returns(Promise.resolve());
+  //     client.indices.open.returns(Promise.resolve());
+  //     sandbox.stub(lib, 'existsIndex').returns(bluebird.resolve(true));
+  //     sandbox.stub(lib, 'putSettings');
+  //
+  //     return fn('pages', {})
+  //       .then(function () {
+  //         sinon.assert.calledOnce(lib.putSettings);
+  //       });
+  //   });
+  //
+  //   it('runs nothing if an index does not exists', function () {
+  //     sandbox.stub(lib, 'existsIndex').returns(bluebird.resolve(false));
+  //     sandbox.stub(lib, 'putSettings');
+  //
+  //     return fn('pages', {})
+  //       .then(function () {
+  //         sinon.assert.notCalled(lib.putSettings);
+  //       });
+  //   });
+  // });
 
   describe('putSettings', function () {
     const fn = lib[this.title];


### PR DESCRIPTION
Rather than adding settings post index creation, make them as the index is created so you don't have to call `.close`