### PR TITLE
Drops support for non-underscored page URIs

### DIFF
--- a/lib/page-list/utils.js
+++ b/lib/page-list/utils.js
@@ -149,8 +149,7 @@ function buildSiteQuery(prefix) {
  * @return {Promise}
  */
 function getSite(uri) {
-  const routeString = _.includes(uri, '/_pages') ? '/_pages' : '/pages',
-    prefix = uri.substring(0, uri.indexOf(routeString));
+  const prefix = uri.substring(0, uri.indexOf('/_pages'));
 
   return elastic.query(SITES_INDEX, buildSiteQuery(prefix))
     .then(function (response) {

--- a/lib/page-list/utils.test.js
+++ b/lib/page-list/utils.test.js
@@ -6,8 +6,7 @@ const _ = require('lodash'),
   sinon = require('sinon'),
   expect = require('chai').expect,
   elastic = require('../services/elastic'),
-  uri = 'domain.com/_pages/abc',
-  uriWithUnderscore = 'domain.com/_pages/abc';
+  uri = 'domain.com/_pages/abc';
 
 describe(`Page List: ${_.startCase(filename)}:`, function () {
   let sandbox, logFn;
@@ -134,13 +133,6 @@ describe(`Page List: ${_.startCase(filename)}:`, function () {
     it('returns site slug if found', function () {
       elastic.query.returns(Promise.resolve({ hits: { hits: [{ _source: { slug: 'siteslug' }}]}}));
       return fn(uri).then(function (result) {
-        expect(result).to.equal('siteslug');
-      });
-    });
-
-    it('handles underscored uris', function () {
-      elastic.query.returns(Promise.resolve({ hits: { hits: [{ _source: { slug: 'siteslug' }}]}}));
-      return fn(uriWithUnderscore).then(function (result) {
         expect(result).to.equal('siteslug');
       });
     });

--- a/lib/services/sitemaps/index.test.js
+++ b/lib/services/sitemaps/index.test.js
@@ -90,10 +90,10 @@ describe(_.startCase(filename), function () {
 
     it ('streams entries by default if custom sitemap does not exist', function () {
       const mockDocs = [{
-          url: 'http://foo.com/pages/1',
+          url: 'http://foo.com/_pages/1',
           publishTime: '2018-01-01'
         }, {
-          url: 'http://foo.com/pages/2',
+          url: 'http://foo.com/_pages/2',
           publishTime: '2018-01-01'
         }],
         mockEsStream = new TestEsStream(mockDocs);
@@ -104,10 +104,10 @@ describe(_.startCase(filename), function () {
         .toPromise(Promise)
         .then(results => {
           expect(results).to.eql([{
-            url: 'http://foo.com/pages/1',
+            url: 'http://foo.com/_pages/1',
             lastmod: '2018-01-01T00:00:00.000Z'
           }, {
-            url: 'http://foo.com/pages/2',
+            url: 'http://foo.com/_pages/2',
             lastmod: '2018-01-01T00:00:00.000Z'
           }]);
           expect(elastic.scrollStream.getCall(0).args[0].index).to.equal('pages');
@@ -117,7 +117,7 @@ describe(_.startCase(filename), function () {
     it ('streams no more than 50,000 entries from default index', function () {
       const mockDocs = _.range(50001)
           .map(() => ({
-            url: 'http://foo.com/pages/1',
+            url: 'http://foo.com/_pages/1',
             publishTime: '2018-01-01'
           })),
         mockEsStream = new TestEsStream(mockDocs);
@@ -163,10 +163,10 @@ describe(_.startCase(filename), function () {
 
     it ('streams entries from sitemaps-entries index if custom sitemap does exist', function () {
       const mockDocs = [{
-          url: 'http://foo.com/pages/1',
+          url: 'http://foo.com/_pages/1',
           lastmod: '2018-01-01T00:00:00.000Z'
         }, {
-          url: 'http://foo.com/pages/2',
+          url: 'http://foo.com/_pages/2',
           publishTime: '2018-01-01T00:00:00.000Z'
         }],
         mockEsStream = new TestEsStream(mockDocs);
@@ -187,7 +187,7 @@ describe(_.startCase(filename), function () {
     it ('streams no more than 50,000 entries from custom sitemap index', function () {
       const mockDocs = _.range(50001)
           .map(() => ({
-            url: 'http://foo.com/pages/1',
+            url: 'http://foo.com/_pages/1',
             publishTime: '2018-01-01'
           })),
         mockEsStream = new TestEsStream(mockDocs);


### PR DESCRIPTION
Amphora-search 6.0 will require all URIs to be underscored, reflecting [Amphora 5](https://github.com/clay/amphora/releases/tag/v5.0.0).