### PR TITLE
Only include docs from the last two days in news sitemap

### DIFF
--- a/lib/services/sitemaps/index.js
+++ b/lib/services/sitemaps/index.js
@@ -130,7 +130,7 @@ function streamNewsEntries(site) {
             }, {
               range: {
                 publication_date: {
-                  gte : 'now-2d/d',
+                  gte : 'now-2d',
                   lt: 'now',
                 }
               }

--- a/lib/services/sitemaps/index.js
+++ b/lib/services/sitemaps/index.js
@@ -123,7 +123,20 @@ function streamNewsEntries(site) {
       size: '50',
       body: {
         sort: [{lastmod: 'desc'}],
-        query: {bool: {filter: {term: {site}}}}
+        query: {
+          bool: {
+            filter: [{
+              term: {site}
+            }, {
+              range: {
+                publication_date: {
+                  gte : 'now-2d/d',
+                  lt: 'now',
+                }
+              }
+            }]
+          }
+        }
       }
     });
 

--- a/lib/services/sitemaps/index.test.js
+++ b/lib/services/sitemaps/index.test.js
@@ -253,8 +253,17 @@ describe(_.startCase(filename), function () {
           expect(elasticOpts.body.sort).to.include({
             lastmod: 'desc'
           });
-          expect(elasticOpts.body.query.bool.filter.term.site)
-            .to.equal('wwwthecut');
+          expect(elasticOpts.body.query.bool.filter).to.include(
+            {term: {site: 'wwwthecut'}}
+          );
+          expect(elasticOpts.body.query.bool.filter).to.include({
+            range: {
+              publication_date: {
+                gte : 'now-2d',
+                lt: 'now',
+              }
+            }
+          });
         });
     });
 


### PR DESCRIPTION
The news sitemap should only include articles from the last two days as per [Google's guide](https://support.google.com/news/publisher/answer/74288?hl=en) on news sitemap creation. This PR modifies amphora's search query to the news-sitemap-entries index so that it only gets articles from the last two days. 