### PR TITLE
Sort news sitemap by published date rather than lastmod

### DIFF
--- a/lib/services/sitemaps.js
+++ b/lib/services/sitemaps.js
@@ -123,7 +123,9 @@ function streamNewsEntries(site) {
       scroll: '10s',
       size: '50',
       body: {
-        sort: [{lastmod: 'desc'}],
+        sort: [{
+          'news:news.news:publication_date': 'desc'
+        }],
         query: {
           bool: {
             filter: [{

--- a/lib/services/sitemaps.test.js
+++ b/lib/services/sitemaps.test.js
@@ -251,7 +251,7 @@ describe(_.startCase(filename), function () {
           expect(results).to.eql(mockDocs);
           expect(elasticOpts.index).to.equal('news-sitemap-entries');
           expect(elasticOpts.body.sort).to.include({
-            lastmod: 'desc'
+            'news:news.news:publication_date': 'desc'
           });
           expect(elasticOpts.body.query.bool.filter).to.include(
             {term: {site: 'wwwthecut'}}


### PR DESCRIPTION
Not strictly required by Google's spec, but this reflects how other publications sort their sitemaps.