### PR TITLE
create page if it doesn't exist when POSTing to _pagelist

### DIFF
--- a/lib/page-list/update.js
+++ b/lib/page-list/update.js
@@ -1,6 +1,8 @@
 'use strict';
-const utils = require('./utils'),
-  userOrRobot = require('../services/clay-user');
+const clayutils = require('clayutils'),
+  utils = require('./utils'),
+  userOrRobot = require('../services/clay-user'),
+  create = require('./create');
 
 
 /**
@@ -32,7 +34,8 @@ function setArchiveState(oldPage, newPage, user) {
 }
 
 /**
- * update the page if it already exists in the pages list
+ * update the page if it already exists in the pages list,
+ * otherwise create it and give it the appropriate data
  * @param {string} uriOrUrl may be a public url, page/preview url, or uri
  * @param {object} data may contain properties that will be added to the page's entry in the list
  * @param {object} user
@@ -50,6 +53,16 @@ function update({ uriOrUrl, data, user }) {
         return utils.updatePage(existingPage.uri, data).then(function () {
           return { uri: existingPage.uri, value: data };
         });
+      } else if (clayutils.isPage(uriOrUrl)) {
+        // page doesn't exist! create it (since we have a /_pages/id uri), then update it with the data we want
+        return create({ uriOrUrl, user })
+          .then(() => {
+            setArchiveState({}, data, user);
+            return utils.updatePage(uriOrUrl, data, user);
+          })
+          .then(() => ({ uri: uriOrUrl, value: data }));
+      } else {
+        throw new Error(`Cannot create page with uri "${uriOrUrl}"`);
       }
     });
 }

--- a/lib/page-list/update.test.js
+++ b/lib/page-list/update.test.js
@@ -69,10 +69,26 @@ describe(`Page List: ${_.startCase(filename)}:`, function () {
     });
   });
 
-  it('does not update page if not found', function () {
+  it('creates page if it does not exist', function () {
+    let creationResult, updateResult;
+
     utils.findPage.returns(Promise.resolve(null));
-    return fn({ uriOrUrl: uri, data: { archived: false, history: [] } }).then(function () {
-      expect(utils.updatePage.called).to.equal(false);
+    utils.getSite.returns(Promise.resolve('foo'));
+    utils.updatePage.returns(Promise.resolve());
+    return fn({ uriOrUrl: uri, data: { archived: false, history: [], title: 'hi' }, user: {} }).then(function () {
+      creationResult = utils.updatePage.getCall(0).args[1],
+      updateResult = utils.updatePage.getCall(1).args[1];
+
+      expect(_.get(creationResult, 'history.0.action')).to.eql('create');
+      expect(updateResult.title).to.eql('hi');
+    });
+  });
+
+  it('throws error if page does not exist and url is not a page uri', function () {
+    utils.findPage.returns(Promise.resolve(null));
+
+    return fn({ uriOrUrl: 'http://domain.com/some-url', data: { title: 'hi' }, user: {} }).catch(function (e) {
+      expect(e.message).to.eql('Cannot create page with uri "http://domain.com/some-url"');
     });
   });
 });


### PR DESCRIPTION
When sending a POST to `_pagelist`, pages should be created if they don't currently exist. This adds that functionality and makes the `pages` index work similarly to `layouts` in its fault-tolerance