### PR TITLE
Updates page mapping to be able to sort by title and authors

### DIFF
--- a/mappings/pages.yml
+++ b/mappings/pages.yml
@@ -12,6 +12,9 @@ _doc:
     title:
       type: text
       analyzer: stdEnglish
+      fields:
+        raw:
+          type: keyword
     titleTruncated:
       type: keyword
     authors:
@@ -21,6 +24,8 @@ _doc:
         english:
           type: text
           analyzer: stdEnglish
+        raw:
+          type: keyword
     users:
       type: nested
       properties:


### PR DESCRIPTION
### Description

* Adds new fields to title and authors mapping
* Enables keyword fields in order to be able to sort by those fields
* This is part of https://github.com/clay/clay-kiln/issues/1403
