### PR TITLE
fix: don't call bluebird.defer

### DIFF
--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -11,7 +11,7 @@ const elastic = require('elasticsearch'),
     apiVersion: '6.x',
     defer: () => {
       let resolve, reject;
-      const promise = new Promise(function () {
+      const promise = new Promise(() => {
         resolve = arguments[0];
         reject = arguments[1];
       });

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -9,7 +9,19 @@ const elastic = require('elasticsearch'),
     host: endpoint,
     maxSockets: 500,
     apiVersion: '6.x',
-    defer: /* istanbul ignore next */ () => bluebird.defer()
+    defer: () => {
+      let resolve, reject;
+      const promise = new Promise(function () {
+        resolve = arguments[0];
+        reject = arguments[1];
+      });
+
+      return {
+        resolve: resolve,
+        reject: reject,
+        promise: promise
+      };
+    }
   },
   FIXED_TYPE = '_doc';
 var log = require('./log').setup({file: __filename}),


### PR DESCRIPTION
Bluebird's defer method is deprecated. Switching to the strategy here http://bluebirdjs.com/docs/api/deferred-migration.html