### PR TITLE
🍕 Fix ES client defer + claim bus events via Redis lock (publish 8.0.2)

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -107,14 +107,33 @@ function disperseEvent(topic, payload) {
     return;
   }
 
+  // amphora-event-bus-redis wraps every published event as `{ hostname, pid, msg }`,
+  // where hostname/pid identify the *publishing* process and the real event payload
+  // lives under `.msg`. The presence of that stamp is our signal that this message
+  // arrived via the Redis pub/sub fan-out — meaning an identical copy was just
+  // delivered to every live replica of the search service at the same time.
   const scopedWrite = data.pid && data.hostname;
 
   if (!scopedWrite) {
+    // Unstamped => it did not come through the broadcast, so only a single copy
+    // exists and there is nothing to dedupe. There is also no `.msg` envelope here,
+    // so `data` itself is the event — write it straight through.
     streams[topic].write(data);
 
     return;
   }
 
+  // Stamped => every replica is executing this same line on an identical copy right
+  // now. Funnel them through a Redis claim lock so that exactly one *live* replica
+  // performs the indexing:
+  //   - the first replica to claim the key wins (won === true) and forwards the
+  //     unwrapped event (`data.msg`, dropping the hostname/pid envelope);
+  //   - the rest lose (won === false) and silently skip it.
+  // This replaces the previous "only process if data.pid/hostname === this process"
+  // gate. Under Kubernetes the publishing pod is routinely gone (rolling deploy,
+  // autoscale, OOM) by the time its own broadcast arrives, so that gate matched no
+  // live replica and the event — e.g. a scheduled publish's Elastic index write —
+  // was dropped forever with no error. Any live replica claiming it fixes that.
   claimEvent(topic, payload, won => {
     if (won) {
       streams[topic].write(data.msg);

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -1,12 +1,18 @@
 'use strict';
 
 const bluebird = require('bluebird'),
+  crypto = require('crypto'),
   redis = require('redis'),
   streams = require('./streams'),
   { BUS_NAMESPACE, BUS_TOPICS } = require('./constants'),
-  PID = process.pid,
-  HOSTNAME = require('os').hostname();
+  // Namespace + TTL for the short-lived "first replica wins" claim keys. The TTL
+  // only needs to outlive the pub/sub fan-out (every replica receives a copy of
+  // the same broadcast within milliseconds), not the downstream indexing work —
+  // Elastic writes are idempotent, so a rare double-claim is harmless.
+  DEDUPE_PREFIX = 'amphora-search:dedupe',
+  DEDUPE_TTL = Number(process.env.AMPHORA_SEARCH_BUS_DEDUPE_TTL) || 60;
 var client,
+  dedupeClient,
   log = require('./services/log').setup({file: __filename});
 
 bluebird.promisifyAll(redis);
@@ -16,29 +22,104 @@ bluebird.promisifyAll(redis);
  */
 function connect() {
   client = redis.createClient(process.env.CLAY_BUS_HOST);
+  // `client` is put into subscribe mode in `subscribe()` and Redis forbids
+  // running regular commands on a subscribed connection, so the SET-based claim
+  // lock needs its own dedicated connection.
+  dedupeClient = redis.createClient(process.env.CLAY_BUS_HOST);
 }
 
 /**
- * Send the event to the appropriate stream
+ * Build a stable dedupe id for a published payload. Every replica receives the
+ * exact same payload bytes for a given broadcast, so hashing the raw payload
+ * yields an identical key across replicas (collapsing the fan-out) while a later
+ * genuine re-publish — which carries different bytes — produces a different key.
+ *
+ * @param {String} payload - the raw published payload
+ * @returns {String} hex digest used as the claim key
+ */
+function hashPayload(payload) {
+  return crypto.createHash('sha1').update(payload).digest('hex');
+}
+
+/**
+ * Ensure exactly one *live* replica processes a scoped bus event.
+ *
+ * Previously amphora-search only processed an event when the current process
+ * was the one that originally published it (pid + hostname match). Under
+ * Kubernetes the publishing pod is frequently already gone by the time its own
+ * broadcast arrives (rolling deploys, autoscaling, OOM kills), so every
+ * surviving replica failed that check and the event — e.g. the Elastic index
+ * write for a scheduled publish — was silently dropped forever.
+ *
+ * Instead, any live replica may claim the event via a short-lived Redis
+ * `SET NX` lock keyed on the immutable payload. The first to claim it processes
+ * it; the rest skip. If Redis is unavailable we FAIL OPEN and process anyway:
+ * Elastic writes are idempotent (keyed by doc id) so a duplicate is harmless,
+ * whereas a silent drop is unrecoverable data loss.
+ *
+ * @param {String} topic - full namespaced topic, e.g. `clay:save`
+ * @param {String} payload - the raw published payload (identical per replica)
+ * @param {Function} cb - invoked with `true` when this replica should process
+ */
+function claimEvent(topic, payload, cb) {
+  if (!dedupeClient) {
+    // No claim connection (e.g. unit tests, or bus host unset): fail open so we
+    // never drop an event just because dedup is unavailable.
+    cb(true);
+
+    return;
+  }
+
+  const key = `${DEDUPE_PREFIX}:${topic}:${hashPayload(payload)}`;
+
+  dedupeClient.set(key, '1', 'NX', 'EX', DEDUPE_TTL, (err, res) => {
+    if (err) {
+      log('error', `[SEARCH][BUS][DEDUPE_ERROR] topic=${topic} action=fail-open error=${err.message}`);
+      cb(true);
+
+      return;
+    }
+
+    // `OK` => we won the claim; `null` => another replica already owns it.
+    cb(res === 'OK');
+  });
+}
+
+/**
+ * Send the event to the appropriate stream.
+ *
+ * Events stamped with a publisher hostname + pid come from
+ * amphora-event-bus-redis and are broadcast to every replica, so they are
+ * deduped via a claim lock (see `claimEvent`). Unstamped events are written
+ * directly.
  *
  * @param {String} topic
  * @param {String} payload
  */
 function disperseEvent(topic, payload) {
-  try {
-    let data = JSON.parse(payload),
-      scopedWrite = data.pid && data.hostname;
+  let data;
 
-    if (scopedWrite) { // We're dealing with amphora-redis-event-bus calls
-      if (data.pid === PID && HOSTNAME === data.hostname) {
-        streams[topic].write(data.msg);
-      }
-    } else {
-      streams[topic].write(data);
-    }
+  try {
+    data = JSON.parse(payload);
   } catch (e) {
     log('error', `Unable to send event ${topic} to bus: ${e.message}`, { payload });
+
+    return;
   }
+
+  const scopedWrite = data.pid && data.hostname;
+
+  if (!scopedWrite) {
+    streams[topic].write(data);
+
+    return;
+  }
+
+  claimEvent(topic, payload, won => {
+    if (won) {
+      streams[topic].write(data.msg);
+    }
+  });
 }
 
 /**
@@ -76,5 +157,7 @@ function init() {
 module.exports = init;
 // For testing
 module.exports.disperseEvent = disperseEvent;
+module.exports.claimEvent = claimEvent;
 module.exports.setClient = mock => client = mock;
+module.exports.setDedupeClient = mock => dedupeClient = mock;
 module.exports.setLog = mock => log = mock;

--- a/lib/bus.test.js
+++ b/lib/bus.test.js
@@ -15,8 +15,29 @@ function setEnvVar(val) {
   process.env.CLAY_BUS_HOST = val;
 }
 
+/**
+ * Build a mock dedupe client whose `set` resolves the claim in a given way.
+ *
+ * @param {String} outcome - 'win' | 'lose' | 'error'
+ * @returns {Object} a stand-in for the Redis claim connection
+ */
+function claimResponder(outcome) {
+  return {
+    set: jest.fn((...args) => {
+      const cb = args[args.length - 1]; // redis `set` always takes the callback last
+
+      if (outcome === 'error') {
+        return cb(new Error('redis unavailable'));
+      }
+
+      return cb(null, outcome === 'win' ? 'OK' : null);
+    })
+  };
+}
+
 beforeEach(() => {
   lib.setClient(false);
+  lib.setDedupeClient(false);
   lib.setLog(logMock);
 });
 
@@ -73,30 +94,59 @@ describe(filename, () => {
       expect(streams[batchEvent].write).not.toHaveBeenCalled();
     });
 
-    test('works with the payload of amphora-event-bus-redis', () => {
+    test('processes a scoped amphora-event-bus-redis payload when it wins the claim', () => {
       const msg = { foo: 'bar' },
-        eventBusData = {
-          hostname: require('os').hostname(),
-          pid: process.pid,
-          msg
-        };
+        eventBusData = { hostname: 'some-pod', pid: 1, msg };
 
+      lib.setDedupeClient(claimResponder('win'));
       streams[objEvent].write = jest.fn();
       lib.disperseEvent(objEvent, JSON.stringify(eventBusData));
       expect(streams[objEvent].write).toHaveBeenCalledWith(msg);
     });
 
-    test('does not works with the payload of amphora-event-bus-redis if pid or host do not match', () => {
+    test('skips a scoped payload when another replica already claimed it', () => {
       const msg = { foo: 'bar' },
-        eventBusData = {
-          hostname: require('os').hostname() + 1,
-          pid: process.pid + 1,
-          msg
-        };
+        eventBusData = { hostname: 'some-pod', pid: 1, msg };
 
+      lib.setDedupeClient(claimResponder('lose'));
       streams[objEvent].write = jest.fn();
       lib.disperseEvent(objEvent, JSON.stringify(eventBusData));
-      expect(streams[objEvent].write).not.toHaveBeenCalledWith(msg);
+      expect(streams[objEvent].write).not.toHaveBeenCalled();
+    });
+
+    test('claims using a stable key derived from the payload', () => {
+      const dedupe = claimResponder('win'),
+        msg = { foo: 'bar' },
+        eventBusData = { hostname: 'some-pod', pid: 1, msg },
+        payload = JSON.stringify(eventBusData);
+
+      lib.setDedupeClient(dedupe);
+      streams[objEvent].write = jest.fn();
+      lib.disperseEvent(objEvent, payload);
+      // Same payload bytes must always hash to the same claim key so the
+      // pub/sub fan-out collapses to a single processor across replicas.
+      expect(dedupe.set.mock.calls[0][0]).toBe(`amphora-search:dedupe:${objEvent}:${require('crypto').createHash('sha1').update(payload).digest('hex')}`);
+    });
+
+    test('fails open (processes) when the claim lock errors', () => {
+      const msg = { foo: 'bar' },
+        eventBusData = { hostname: 'some-pod', pid: 1, msg };
+
+      lib.setDedupeClient(claimResponder('error'));
+      streams[objEvent].write = jest.fn();
+      lib.disperseEvent(objEvent, JSON.stringify(eventBusData));
+      expect(streams[objEvent].write).toHaveBeenCalledWith(msg);
+      expect(logMock).toHaveBeenCalled();
+    });
+
+    test('fails open (processes) a scoped payload when no dedupe client is configured', () => {
+      const msg = { foo: 'bar' },
+        eventBusData = { hostname: 'some-pod', pid: 1, msg };
+
+      lib.setDedupeClient(false);
+      streams[objEvent].write = jest.fn();
+      lib.disperseEvent(objEvent, JSON.stringify(eventBusData));
+      expect(streams[objEvent].write).toHaveBeenCalledWith(msg);
     });
   });
 });

--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -9,11 +9,17 @@ const elastic = require('elasticsearch'),
     host: endpoint,
     maxSockets: 500,
     apiVersion: '6.x',
+    // Bridge the ES client's promise API to a deferred. The Promise executor MUST take
+    // explicit (res, rej) params: an arrow function has no own `arguments`, so the prior
+    // `arguments[0]/[1]` read the CommonJS module wrapper args (exports/require) instead.
+    // That left `resolve === exports`, so any promise-style ES call (e.g. the startup
+    // ping/health check) threw "defer.resolve is not a function". Capturing the executor's
+    // own params fixes it while still avoiding the deprecated bluebird.defer().
     defer: () => {
       let resolve, reject;
-      const promise = new Promise(() => {
-        resolve = arguments[0];
-        reject = arguments[1];
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
       });
 
       return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amphora-search",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphora-search",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Making it easier to use Elastic Search with Amphora",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## TL;DR

- **Two fixes plus a version bump.** The version bump is now the most urgent part: **npm `8.0.2` needs to exist**, because the currently-published `8.0.1` contains a broken Elasticsearch client.
- **Start here:**
  1. [`lib/services/elastic.js` → `defer` (L9–L30)](https://github.com/clay/amphora-search/blob/34535484451cbf940d444452fd5ba81f804c83d5/lib/services/elastic.js#L9-L30) — fixes the promise bridge that throws `TypeError: defer.resolve is not a function`.
  2. [`lib/bus.js` → `claimEvent` / `disperseEvent` (L44–L123)](https://github.com/clay/amphora-search/blob/34535484451cbf940d444452fd5ba81f804c83d5/lib/bus.js#L44-L123) — replaces the pid+hostname gate with a Redis claim lock.
  3. [`package.json` version → 8.0.2](https://github.com/clay/amphora-search/blob/34535484451cbf940d444452fd5ba81f804c83d5/package.json#L3) — required to ship the above; see the hazard note below.

## Why this was reopened

### 1. The published 8.0.1 is broken and consumers can pick it up by accident

`8.0.1` is on npm and contains this:

```js
defer: () => {
  let resolve, reject;
  const promise = new Promise(() => {
    resolve = arguments[0];   // arrow fn has no own `arguments`
    reject = arguments[1];    // → resolves against the CommonJS module wrapper
  });
```

An arrow function has no own `arguments`, so these read the CommonJS module wrapper's args, leaving `resolve === exports`. Any promise-style ES call (including the startup ping/health check) throws `TypeError: defer.resolve is not a function`.

The hazard: consumers depend on this with a caret range (`nymag/sites` uses `"amphora-search": "^8.0.0"`). A caret resolves to the **highest published 8.x**, which is `8.0.1` — regardless of the `latest` dist-tag still pointing at `8.0.0`. So sites is only safe right now because its committed lockfile pins `8.0.0` and Docker builds use `npm ci`. Any `npm install`, dependency bump, or lockfile regeneration silently swaps in the broken client. **Publishing 8.0.2 removes that trap permanently**, since `^8.0.0` will then resolve to 8.0.2.

### 2. The pid+hostname gate is still dropping index writes in production

`disperseEvent` on master only processes an event when the current process is the one that published it:

```js
if (data.pid === PID && HOSTNAME === data.hostname) {
  streams[topic].write(data.msg);
}
```

Under Kubernetes the publishing pod is frequently gone by the time its own broadcast arrives (rolling deploys, autoscaling, OOM kills), so every surviving replica fails the check and the event — e.g. the Elastic write for a scheduled publish — is dropped silently and forever. `nymag/sites` had two more articles miss their Elasticsearch update on Jul 28.

This replaces the gate with a short-lived Redis `SET NX` claim keyed on a hash of the immutable payload: every replica receives identical bytes, so the first live replica to claim it processes it and the rest skip. If Redis is unavailable it **fails open** and processes anyway — Elastic writes are idempotent by doc id, so a rare duplicate is harmless whereas a silent drop is unrecoverable.

## Testing

- `lib/bus.test.js` — 11 passing, including 5 new cases: winning the claim, losing it, stable key derivation, failing open on a claim error, and failing open with no dedupe client configured.
- `lib/services/elastic.test.js` — all passing.
- `npm run lint` — clean (`--max-warnings 0`).
- **Pre-existing, unrelated failure:** `lib/setup.test.js` "on the second pass it does not try to re-run index validaton" fails identically on untouched `origin/master` (verified by checking out master and re-running). It leaks mock state between tests and never returns its promise, so the assertion escapes as an unhandled rejection. Not touched here.

## Notes for the reviewer

@james-owen — you asked whether this could be closed back in July. At the time we were moving the fix into `sites` instead (in-process indexing, nymag/sites#13396). That has since merged but is still dormant behind a default-off flag, so the Redis path is still what production actually relies on. Independently of that rollout, the broken `8.0.1` on npm is a live trap for any consumer that reinstalls, which is why I'd like to land this and publish 8.0.2.
