### PR TITLE
fix: elastic client defer() captured arguments from the wrong scope

### DIFF
--- a/lib/services/elastic.js
+++ b/lib/services/elastic.js
@@ -5,23 +5,29 @@ const elastic = require('elasticsearch'),
   bluebird = require('bluebird'),
   _ = require('lodash'),
   endpoint = process.env.ELASTIC_HOST || '',
+  /**
+   * Builds the `{ promise, resolve, reject }` triple the elasticsearch client's `defer` option
+   * expects -- it calls `defer.resolve(body)` in src/lib/transport.js.
+   *
+   * Stays a bluebird promise because that is what `bluebird.defer()` returned, so callers keep
+   * any bluebird-specific methods they were using.
+   *
+   * @returns {Object} { promise, resolve, reject }
+   */
+  makeDeferred = () => {
+    let resolve, reject;
+    const promise = new bluebird((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    return { promise, resolve, reject };
+  },
   serverConfig = {
     host: endpoint,
     maxSockets: 500,
     apiVersion: '6.x',
-    defer: () => {
-      let resolve, reject;
-      const promise = new Promise(() => {
-        resolve = arguments[0];
-        reject = arguments[1];
-      });
-
-      return {
-        resolve: resolve,
-        reject: reject,
-        promise: promise
-      };
-    }
+    defer: makeDeferred
   },
   FIXED_TYPE = '_doc';
 var log = require('./log').setup({file: __filename}),
@@ -547,6 +553,8 @@ function findIndexFromAlias(index) {
 }
 
 module.exports.setup = setup;
+// exported so the `defer` contract is under test
+module.exports.makeDeferred = makeDeferred;
 module.exports.endpoint = endpoint;
 module.exports.healthCheck = healthCheck;
 module.exports.initIndex = initIndex;

--- a/lib/services/elastic.test.js
+++ b/lib/services/elastic.test.js
@@ -47,6 +47,47 @@ beforeEach(() => {
 });
 
 describe(filename, () => {
+  // The elasticsearch client calls `defer.resolve(parsedBody)` for every response
+  // (src/lib/transport.js), so if this contract is wrong nothing works at all -- and the version
+  // that shipped in v8.0.1 was wrong, undetected, because no test ever invoked it.
+  describe('makeDeferred', () => {
+    test('returns a resolve function, a reject function, and a thenable', () => {
+      const deferred = lib.makeDeferred();
+
+      expect(typeof deferred.resolve).toBe('function');
+      expect(typeof deferred.reject).toBe('function');
+      expect(typeof deferred.promise.then).toBe('function');
+    });
+
+    test('resolving settles the promise with the value the client passes', () => {
+      const deferred = lib.makeDeferred();
+
+      deferred.resolve({ parsed: 'body' });
+
+      return deferred.promise.then(value => expect(value).toEqual({ parsed: 'body' }));
+    });
+
+    test('rejecting settles the promise with the error', () => {
+      const deferred = lib.makeDeferred(),
+        err = new Error('request failed');
+
+      deferred.reject(err);
+
+      return deferred.promise.then(
+        () => { throw new Error('expected the deferred promise to reject'); },
+        caught => expect(caught).toBe(err)
+      );
+    });
+
+    test('hands back a distinct deferred each call', () => {
+      const first = lib.makeDeferred(),
+        second = lib.makeDeferred();
+
+      expect(first.promise).not.toBe(second.promise);
+      expect(first.resolve).not.toBe(second.resolve);
+    });
+  });
+
   describe('setup', () => {
     test('creates an Elastic client if an endpoint is defined and no override is passed in', () => {
       return expect(lib.setup()).rejects.toThrow();


### PR DESCRIPTION
The `defer` option we pass the elasticsearch client reads `arguments[0]` and `arguments[1]`
inside an arrow function, which doesn't have its own `arguments`, so they resolve to the
CommonJS wrapper's--`resolve` becomes `exports`. The client calls `defer.resolve(parsedBody)`
on every request, so every query fails with `TypeError: defer.resolve is not a function`.

This defer error breaks search. Npm latest is 8.0.0, so this goes out as the next version and
8.0.1 won't get tagged as latest.

Captures `resolve`/`reject` off the executor's parameters instead. Exported as `makeDeferred` so
it's under test--nothing called `defer` in current tests.