### PR TITLE
feat: setup non-highland event interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ module.exports = require('./lib/init');
 
 // Allow subscription to Streams
 module.exports.subscribe = streams.subscribe;
+module.exports.on = streams.on;
+
+// Consumers that own their own event source (nymag/sites publishes in-process) call this instead
+// of going back out over redis.
+module.exports.dispatch = streams.dispatch;
 
 // Export helper functions for indices in a Clay instance
 module.exports.elastic = elastic;

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -29,12 +29,14 @@ function disperseEvent(topic, payload) {
     let data = JSON.parse(payload),
       scopedWrite = data.pid && data.hostname;
 
+    // `topic` arrives namespaced (`clay:save`) because that is what we subscribed to; dispatch
+    // accepts either form.
     if (scopedWrite) { // We're dealing with amphora-redis-event-bus calls
       if (data.pid === PID && HOSTNAME === data.hostname) {
-        streams[topic].write(data.msg);
+        streams.dispatch(topic, data.msg);
       }
     } else {
-      streams[topic].write(data);
+      streams.dispatch(topic, data);
     }
   } catch (e) {
     log('error', `Unable to send event ${topic} to bus: ${e.message}`, { payload });

--- a/lib/bus.test.js
+++ b/lib/bus.test.js
@@ -48,29 +48,35 @@ describe(filename, () => {
     });
   });
 
+  // `disperseEvent` parses the payload, applies the same-process gate, and hands off to
+  // `streams.dispatch`. What dispatch then does with it -- native handlers, and the legacy
+  // Highland stream if anything forked it -- is streams.test.js's business, so these assert on
+  // the hand-off rather than on a stream write.
   describe('disperseEvent', () => {
     const objEvent = 'clay:saveUser',
       objString = '{"username": "foo"}',
       batchEvent = 'clay:save',
       batchString = '[{"key": "foo.com/_components/bar"}, {"key": "foo.com/_components/baz"}]';
 
-    test('writes to the appropriate stream with one object', () => {
-      streams[objEvent].write = jest.fn();
-      lib.disperseEvent(objEvent, objString);
-      expect(streams[objEvent].write).toHaveBeenCalledWith(JSON.parse(objString));
+    beforeEach(() => {
+      streams.dispatch = jest.fn();
     });
 
-    test('writes to the appropriate streams', () => {
-      streams[batchEvent].write = jest.fn();
+    test('dispatches one object to the matching topic', () => {
+      lib.disperseEvent(objEvent, objString);
+      expect(streams.dispatch).toHaveBeenCalledWith(objEvent, JSON.parse(objString));
+    });
+
+    test('dispatches a batch once', () => {
       lib.disperseEvent(batchEvent, batchString);
-      expect(streams[batchEvent].write).toHaveBeenCalledTimes(1);
+      expect(streams.dispatch).toHaveBeenCalledTimes(1);
+      expect(streams.dispatch).toHaveBeenCalledWith(batchEvent, JSON.parse(batchString));
     });
 
     test('catches JSON.parse error', () => {
-      streams[batchEvent].write = jest.fn();
       lib.disperseEvent(batchEvent, 'not a JSON string');
       expect(logMock).toHaveBeenCalled();
-      expect(streams[batchEvent].write).not.toHaveBeenCalled();
+      expect(streams.dispatch).not.toHaveBeenCalled();
     });
 
     test('works with the payload of amphora-event-bus-redis', () => {
@@ -81,9 +87,8 @@ describe(filename, () => {
           msg
         };
 
-      streams[objEvent].write = jest.fn();
       lib.disperseEvent(objEvent, JSON.stringify(eventBusData));
-      expect(streams[objEvent].write).toHaveBeenCalledWith(msg);
+      expect(streams.dispatch).toHaveBeenCalledWith(objEvent, msg);
     });
 
     test('does not works with the payload of amphora-event-bus-redis if pid or host do not match', () => {
@@ -94,9 +99,8 @@ describe(filename, () => {
           msg
         };
 
-      streams[objEvent].write = jest.fn();
       lib.disperseEvent(objEvent, JSON.stringify(eventBusData));
-      expect(streams[objEvent].write).not.toHaveBeenCalledWith(msg);
+      expect(streams.dispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/lib/lists/index.js
+++ b/lib/lists/index.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const h = require('highland'),
-  { isLayout } = require('clayutils'),
-  { subscribe } = require('../streams'),
+const { isLayout } = require('clayutils'),
+  // Required as a namespace rather than destructured so `streams.on` is looked up at call time
+  // and a test can stub it. (The previous `{ subscribe }` destructure meant the existing
+  // "does not subscribe if false" test could only ever pass, mock or not.)
+  streams = require('../streams'),
   pageList = require('./page-list'),
   layoutList = require('./layout-list'),
   userList = require('./user-list'),
@@ -11,26 +13,31 @@ const h = require('highland'),
 var log = require('../services/log').setup({ file: __filename }),
   RUN_INTERNAL_PROCESS = process.env.AMPHORA_SEARCH_UPDATE_LISTS !== 'false';
 
+/**
+ * Wrap a list updater so it keeps the contract the Highland chains had: log the result on
+ * success, log the error on failure, and never reject. `dispatch` also guards against a
+ * rejecting handler, but each of these owns its own success log, so they need the `then` anyway.
+ *
+ * @param {Function} update - `(payload) => Promise<Object>`
+ * @returns {Function} a handler safe to hand to `on`
+ */
+function settleWith(update) {
+  return payload => Promise.resolve()
+    .then(() => update(payload))
+    .then(logStatus)
+    .catch(handleErrors);
+}
+
 function setSubscribers() {
   if (RUN_INTERNAL_PROCESS) {
     // For meta updates
-    subscribe('saveMeta')
-      .map(handleMetaSave)
-      .merge()
-      .errors(handleErrors)
-      .each(logStatus);
+    streams.on('saveMeta', settleWith(handleMetaSave));
 
     // For adding to users index
-    subscribe('saveUser')
-      .flatMap(userList.updateUserList)
-      .errors(handleErrors)
-      .each(logStatus);
+    streams.on('saveUser', settleWith(userList.updateUserList));
 
     // For removing from users index
-    subscribe('deleteUser')
-      .flatMap(userList.removeUser)
-      .errors(handleErrors)
-      .each(logStatus);
+    streams.on('deleteUser', settleWith(userList.removeUser));
   }
 }
 
@@ -59,12 +66,10 @@ function logStatus(resp) {
  * @param {Object} payload
  * @param {String} payload.uri
  * @param {Object} payload.data
- * @returns {Stream}
+ * @returns {Promise}
  */
 function handleMetaSave({ uri, data }) {
-  const promise = isLayout(uri) ? layoutList.updateLayout(uri, data) : pageList.updatePage(uri, data);
-
-  return h(promise);
+  return isLayout(uri) ? layoutList.updateLayout(uri, data) : pageList.updatePage(uri, data);
 }
 
 /**
@@ -90,6 +95,7 @@ module.exports = setup;
 module.exports.handleErrors = handleErrors;
 module.exports.handleMetaSave = handleMetaSave;
 module.exports.logStatus = logStatus;
+module.exports.settleWith = settleWith;
 module.exports.setLog = mock => log = mock;
 module.exports.setSubscribers = setSubscribers;
 module.exports.setInternal = mock => RUN_INTERNAL_PROCESS = mock;

--- a/lib/lists/index.test.js
+++ b/lib/lists/index.test.js
@@ -11,7 +11,7 @@ const filename = __filename.split('/').pop().split('.').shift(),
 
 pageList.updatePage = jest.fn();
 layoutList.updateLayout = jest.fn();
-streams.subscribe = jest.fn();
+streams.on = jest.fn();
 
 beforeEach(() => {
   lib.setLog(logMock);
@@ -37,7 +37,6 @@ describe(filename, () => {
     test('it calls the update function for the layout list', () => {
       layoutList.updateLayout.mockResolvedValue();
       return lib.handleMetaSave({ uri: 'foo.com/_layouts/foo/instances/bar', data: {}})
-        .toPromise(Promise)
         .then(() => {
           expect(layoutList.updateLayout).toHaveBeenCalled();
         });
@@ -46,7 +45,6 @@ describe(filename, () => {
     test('it calls the update function for the page list', () => {
       pageList.updatePage.mockResolvedValue();
       return lib.handleMetaSave({ uri: 'foo.com/_pages/foo', data: {}})
-        .toPromise(Promise)
         .then(() => {
           expect(pageList.updatePage).toHaveBeenCalled();
         });
@@ -71,7 +69,15 @@ describe(filename, () => {
     test('it does not subscribe to bus topics if false', () => {
       lib.setInternal(false);
       lib.setSubscribers();
-      expect(streams.subscribe).not.toHaveBeenCalled();
+      expect(streams.on).not.toHaveBeenCalled();
+    });
+
+    test('it registers a native handler per internal topic when enabled', () => {
+      lib.setInternal(true);
+      lib.setSubscribers();
+      expect(streams.on.mock.calls.map(call => call[0]))
+        .toEqual(['saveMeta', 'saveUser', 'deleteUser']);
+      streams.on.mock.calls.forEach(call => expect(typeof call[1]).toBe('function'));
     });
   });
 });

--- a/lib/lists/user-list.js
+++ b/lib/lists/user-list.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const h = require('highland'),
-  elastic = require('../services/elastic'),
+const elastic = require('../services/elastic'),
   { indexWithPrefix } = require('../services/elastic-helpers'),
   USER_STRING = '/_users/';
 var USERS_INDEX,
@@ -27,22 +26,22 @@ function handleResult(resp, msg) {
  *
  * @param  {Object} key
  * @param  {Object} value
- * @return {Stream}
+ * @return {Promise}
  */
 function updateUserList({ key, value:userData }) {
   key = key.replace(USER_STRING, '');
 
-  return h(elastic.update(USERS_INDEX, key, userData, false, true));
+  return elastic.update(USERS_INDEX, key, userData, false, true);
 }
 
 /**
  * Remove a user from the users index
  *
  * @param {String} user
- * @returns {Stream}
+ * @returns {Promise}
  */
 function removeUser({ uri }) {
-  return h(elastic.del(USERS_INDEX, uri.replace(USER_STRING, '')));
+  return elastic.del(USERS_INDEX, uri.replace(USER_STRING, ''));
 }
 
 module.exports.setUserIndex = () => USERS_INDEX = indexWithPrefix('users');

--- a/lib/lists/user-list.test.js
+++ b/lib/lists/user-list.test.js
@@ -24,8 +24,6 @@ describe(filename, () => {
       elastic.del.mockResolvedValue(true);
 
       return lib.removeUser({ uri: '/_users/foo'})
-        .collect()
-        .toPromise(Promise)
         .then(() => {
           expect(elastic.del).toHaveBeenCalled();
         });
@@ -38,8 +36,6 @@ describe(filename, () => {
 
       elastic.update.mockResolvedValue(true);
       return lib.updateUserList({ key: '/_users/foo', value })
-        .collect()
-        .toPromise(Promise)
         .then(() => {
           expect(elastic.update).toHaveBeenCalledWith('users', 'foo', value, false, true);
         });

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,27 +1,192 @@
 'use strict';
 
+// Event delivery for amphora bus topics.
+//
+// Two APIs live here during the Highland migration:
+//
+//   - `on(topic, handler)`  -- the native one. Plain functions, called directly by `dispatch`.
+//   - `subscribe(topic)`    -- the legacy one. Returns a Highland stream fork. Deprecated, but
+//                              still the only thing the ~15 handlers in nymag/sites use, so it
+//                              stays until they are ported.
+//
+// `dispatch` feeds both, so a consumer can be moved from one to the other one at a time with no
+// flag and no coordinated release.
+
 const _ = require('lodash'),
   h = require('highland'),
   { BUS_NAMESPACE, BUS_TOPICS } = require('./constants'),
-  STREAMS = {}; // Placeholder to be filled with streams
+  STREAMS = {}, // legacy Highland stream per topic
+  HANDLERS = {}, // topic -> [handler], the native replacement for STREAMS
+  // Topics something has actually forked via `subscribe`. Writing to an unforked Highland
+  // stream buffers the value forever, so `dispatch` must not do it -- see the note on
+  // `dispatch` below.
+  LEGACY_FORKED = new Set();
+var log = require('./services/log').setup({ file: __filename });
+
+/**
+ * Drop the bus namespace from a topic, if it's there.
+ *
+ * Every API here accepts either form. Callers legitimately have both: amphora publishes and
+ * Redis delivers `clay:save`, while the handler manifest and BUS_TOPICS use `save`. Accepting
+ * both means a caller never has to know which one it's holding, and nymag/sites can drop its own
+ * copy of this logic (search/bus/streams.js#stripNamespace).
+ *
+ * @param {String} topic - e.g. `clay:save` or `save`
+ * @returns {String} e.g. `save`
+ */
+function stripNamespace(topic) {
+  const prefix = `${BUS_NAMESPACE}:`;
+
+  return typeof topic === 'string' && topic.startsWith(prefix)
+    ? topic.slice(prefix.length)
+    : topic;
+}
+
+/**
+ * @param {String} topic - namespaced or not
+ * @returns {String} the bare topic
+ * @throws {Error} if the topic is not one amphora publishes
+ */
+function assertKnownTopic(topic) {
+  const bare = stripNamespace(topic);
+
+  if (BUS_TOPICS.indexOf(bare) === -1) {
+    throw new Error('Stream `subscribe` called with an invalid event!');
+  }
+
+  return bare;
+}
+
+/**
+ * Register a plain function to receive a topic's payloads.
+ *
+ * The native replacement for `subscribe`. The handler is called once per event with its own
+ * deep clone of the payload, so it can mutate freely without affecting other consumers -- the
+ * same isolation `subscribe`'s per-fork `cloneDeep` gives, without the stream.
+ *
+ * A handler may return a Promise; `dispatch` will attach a rejection handler to it but will not
+ * wait for it. Delivery is fire-and-forget in both APIs: a handler cannot fail the publish that
+ * produced the event, and cannot affect any other handler.
+ *
+ * @param {String} topic - one of BUS_TOPICS, namespaced or not
+ * @param {Function} handler - `(payload) => void|Promise`
+ * @throws {Error} on an unknown topic or a non-function handler
+ */
+function on(topic, handler) {
+  const bare = assertKnownTopic(topic);
+
+  if (typeof handler !== 'function') {
+    throw new Error('Stream `on` requires a handler function');
+  }
+
+  if (!HANDLERS[bare]) {
+    HANDLERS[bare] = [];
+  }
+
+  HANDLERS[bare].push(handler);
+}
 
 /**
  * Get a fork of a specific Stream that corresponds
  * to an event from Amphora
  *
+ * @deprecated use `on(topic, handler)`. Kept because nymag/sites' handlers still consume
+ *  Highland streams; remove once they are ported.
  * @param  {String} e
  * @return {Stream}
  */
 function subscribe(e) {
-  if (BUS_TOPICS.indexOf(e) === -1) {
-    throw new Error('Stream `subscribe` called with an invalid event!');
+  const bare = assertKnownTopic(e);
+
+  LEGACY_FORKED.add(bare);
+
+  if (bare === 'save' || bare === 'delete') {
+    return STREAMS[bare].fork().map(ops => h(_.cloneDeep(ops)));
   }
 
-  if (e === 'save' || e === 'delete') {
-    return STREAMS[e].fork().map(ops => h(_.cloneDeep(ops)));
+  return STREAMS[bare].fork().map(_.cloneDeep);
+}
+
+/**
+ * Log a handler failure without letting it escape. Native handlers are isolated from each
+ * other and from the caller, matching what `.errors(...)` did for the Highland consumers.
+ *
+ * @param {String} topic
+ * @param {Error} err
+ */
+function logHandlerError(topic, err) {
+  log('error', `Error in ${topic} handler: ${err.message}`, { stack: err.stack });
+}
+
+/**
+ * Deliver one event to every consumer of a topic.
+ *
+ * Native handlers run first, each with its own clone, each isolated: a throw or a rejection is
+ * logged and cannot reach the caller or the other handlers. Then the legacy Highland stream is
+ * written, if anything forked it.
+ *
+ * That `LEGACY_FORKED` check is a behaviour change worth knowing about: this used to be an
+ * unconditional `streams[topic].write(...)` from lib/bus.js, and a Highland stream with no fork
+ * buffers everything written to it for the life of the process. The bus subscribes to every
+ * topic in BUS_TOPICS regardless of whether anything consumes it, so the unconsumed ones were
+ * accumulating in memory forever.
+ *
+ * Which topics those are, measured against nymag/sites rather than assumed (an earlier version
+ * of this comment wrongly listed `publishPage`):
+ *   consumed   save, unpublishPage      -- search/handlers/*.js
+ *   consumed   publishPage              -- amphora/plugins/{syndication,coral-hook}.js, both
+ *                                         calling this module's `subscribe` directly
+ *   consumed   saveMeta, saveUser, deleteUser -- lib/lists/index.js, now via `on` rather than
+ *                                         `subscribe`, so their legacy streams are deliberately
+ *                                         unforked from here on
+ *   unconsumed createPage, delete, publishLayout -- these are the leak
+ *
+ * Dropping an event nobody consumes is safe because registration always precedes delivery:
+ * handlers subscribe while `setup()` requires them (lib/setup.js:73-75), the internal list
+ * subscribers register at require time (lib/lists/index.js), and only then does `onInit` connect
+ * the bus -- `setup(options).then(bus)` at lib/init.js:39-40.
+ *
+ * @param {String} topic - namespaced (`clay:save`) or not (`save`)
+ * @param {Object|Array} payload - the event payload
+ */
+function dispatch(topic, payload) {
+  const bare = assertKnownTopic(topic),
+    handlers = HANDLERS[bare] || [];
+
+  // TEMPORARY POC instrumentation, matching nymag/sites' [SEARCH][TRACE] tag so one publish can
+  // be followed across both repos. Off unless SEARCH_TRACE=true. Counts and topics only.
+  if (process.env.SEARCH_TRACE === 'true') {
+    log('info', `[SEARCH][TRACE][AS_DISPATCH] topic=${bare} nativeHandlers=${handlers.length} ` +
+      `legacyForked=${LEGACY_FORKED.has(bare)}`);
   }
 
-  return STREAMS[e].fork().map(_.cloneDeep);
+  for (const handler of handlers) {
+    try {
+      const result = handler(_.cloneDeep(payload));
+
+      if (result && typeof result.then === 'function') {
+        result.catch(err => logHandlerError(bare, err));
+      }
+    } catch (err) {
+      logHandlerError(bare, err);
+    }
+  }
+
+  if (LEGACY_FORKED.has(bare)) {
+    STREAMS[bare].write(payload);
+  }
+}
+
+/**
+ * Whether anything is listening to a topic, on either API. Diagnostic only.
+ *
+ * @param {String} topic
+ * @returns {Boolean}
+ */
+function hasSubscribers(topic) {
+  const bare = stripNamespace(topic);
+
+  return Boolean(HANDLERS[bare] && HANDLERS[bare].length) || LEGACY_FORKED.has(bare);
 }
 
 /**
@@ -35,3 +200,14 @@ for (let i = 0; i < BUS_TOPICS.length; i++) {
 }
 
 module.exports.subscribe = subscribe;
+module.exports.on = on;
+module.exports.stripNamespace = stripNamespace;
+module.exports.dispatch = dispatch;
+module.exports.hasSubscribers = hasSubscribers;
+
+// For testing
+module.exports.setLog = mock => log = mock;
+module.exports.reset = () => {
+  Object.keys(HANDLERS).forEach(topic => delete HANDLERS[topic]);
+  LEGACY_FORKED.clear();
+};

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -195,13 +195,6 @@ function dispatch(topic, payload) {
   const bare = assertKnownTopic(topic),
     handlers = HANDLERS[bare] || [];
 
-  // TEMPORARY POC instrumentation, matching nymag/sites' [SEARCH][TRACE] tag so one publish can
-  // be followed across both repos. Off unless SEARCH_TRACE=true. Counts and topics only.
-  if (process.env.SEARCH_TRACE === 'true') {
-    log('info', `[SEARCH][TRACE][AS_DISPATCH] topic=${bare} nativeHandlers=${handlers.length} ` +
-      `legacyForked=${LEGACY_FORKED.has(bare)}`);
-  }
-
   for (const { handler, filter } of handlers) {
     try {
       // Filter before cloning, per handler -- see `select` and the note at the top of this file.

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -11,12 +11,29 @@
 //
 // `dispatch` feeds both, so a consumer can be moved from one to the other one at a time with no
 // flag and no coordinated release.
+//
+// Both APIs take an OPTIONAL `filter` predicate, which is the single largest efficiency win
+// available here. Every consumer gets its own deep clone of the payload for isolation, and for the
+// `save` topic that payload is the whole ops array -- so N consumers cloned N x (all ops) and then
+// each threw away the ~99% they did not want. Passing the predicate in lets the clone happen
+// *after* selection instead of before.
+//
+// Benchmarked on a real 67-op homepage publish delivered to 15 consumers (nymag/sites
+// .idea/highland-removal/bench): 1.4-2.7x less CPU per publish depending on payload shape, and it
+// works with the Highland fork still in place -- it does not require porting any consumer. The
+// saving is in object count, not bytes: `op.value` is a JSON string that cloneDeep shares by
+// reference, so what is avoided is allocating (and immediately discarding) one object per op per
+// consumer.
+//
+// Safe because selection strictly precedes mutation: the predicate only reads `op.key`/`op.value`,
+// and the first thing any consumer mutates is the clone. Omitting `filter` keeps the old
+// behaviour exactly, so this is backwards compatible for callers that do not pass one.
 
 const _ = require('lodash'),
   h = require('highland'),
   { BUS_NAMESPACE, BUS_TOPICS } = require('./constants'),
   STREAMS = {}, // legacy Highland stream per topic
-  HANDLERS = {}, // topic -> [handler], the native replacement for STREAMS
+  HANDLERS = {}, // topic -> [{ handler, filter }], the native replacement for STREAMS
   // Topics something has actually forked via `subscribe`. Writing to an unforked Highland
   // stream buffers the value forever, so `dispatch` must not do it -- see the note on
   // `dispatch` below.
@@ -40,6 +57,24 @@ function stripNamespace(topic) {
   return typeof topic === 'string' && topic.startsWith(prefix)
     ? topic.slice(prefix.length)
     : topic;
+}
+
+/**
+ * Apply a consumer's own predicate before it gets its clone, so the clone covers only the ops it
+ * actually wants. See the note at the top of this file for why this is the main win here.
+ *
+ * Deliberately conservative: only filters when a predicate was supplied AND the payload is an
+ * array. `save` and `delete` carry an ops array; every other topic carries a single object
+ * (`unpublishPage` is `{ uri, url, user }`), and filtering those would be meaningless.
+ *
+ * @param {Object|Array} payload
+ * @param {Function} [filter] - `(op) => Boolean`, read-only
+ * @returns {Object|Array} the payload, or the subset the consumer selected
+ */
+function select(payload, filter) {
+  return typeof filter === 'function' && Array.isArray(payload)
+    ? payload.filter(filter)
+    : payload;
 }
 
 /**
@@ -70,9 +105,12 @@ function assertKnownTopic(topic) {
  *
  * @param {String} topic - one of BUS_TOPICS, namespaced or not
  * @param {Function} handler - `(payload) => void|Promise`
+ * @param {Function} [filter] - `(op) => Boolean`. When given, and the topic carries an ops array,
+ *  this handler is cloned only the ops the predicate selects. Pass the same predicate the handler
+ *  applies as its first stage; filtering twice is idempotent. See the note at the top of this file.
  * @throws {Error} on an unknown topic or a non-function handler
  */
-function on(topic, handler) {
+function on(topic, handler, filter) {
   const bare = assertKnownTopic(topic);
 
   if (typeof handler !== 'function') {
@@ -83,7 +121,7 @@ function on(topic, handler) {
     HANDLERS[bare] = [];
   }
 
-  HANDLERS[bare].push(handler);
+  HANDLERS[bare].push({ handler, filter });
 }
 
 /**
@@ -93,15 +131,19 @@ function on(topic, handler) {
  * @deprecated use `on(topic, handler)`. Kept because nymag/sites' handlers still consume
  *  Highland streams; remove once they are ported.
  * @param  {String} e
+ * @param  {Function} [filter] - `(op) => Boolean`. When given, and the topic carries an ops array,
+ *  this fork is cloned from only the ops the predicate selects instead of from all of them. Pass
+ *  the same predicate the consumer applies as its first stage and the result is identical, because
+ *  filtering twice is idempotent. See the note at the top of this file.
  * @return {Stream}
  */
-function subscribe(e) {
+function subscribe(e, filter) {
   const bare = assertKnownTopic(e);
 
   LEGACY_FORKED.add(bare);
 
   if (bare === 'save' || bare === 'delete') {
-    return STREAMS[bare].fork().map(ops => h(_.cloneDeep(ops)));
+    return STREAMS[bare].fork().map(ops => h(_.cloneDeep(select(ops, filter))));
   }
 
   return STREAMS[bare].fork().map(_.cloneDeep);
@@ -160,9 +202,10 @@ function dispatch(topic, payload) {
       `legacyForked=${LEGACY_FORKED.has(bare)}`);
   }
 
-  for (const handler of handlers) {
+  for (const { handler, filter } of handlers) {
     try {
-      const result = handler(_.cloneDeep(payload));
+      // Filter before cloning, per handler -- see `select` and the note at the top of this file.
+      const result = handler(_.cloneDeep(select(payload, filter)));
 
       if (result && typeof result.then === 'function') {
         result.catch(err => logHandlerError(bare, err));

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,33 +1,11 @@
 'use strict';
 
-// Event delivery for amphora bus topics.
+// Event delivery for amphora bus topics. Two APIs:
 //
-// Two APIs live here during the Highland migration:
+//   on(topic, handler)   plain function, called by `dispatch`
+//   subscribe(topic)     highland stream fork, deprecated
 //
-//   - `on(topic, handler)`  -- the native one. Plain functions, called directly by `dispatch`.
-//   - `subscribe(topic)`    -- the legacy one. Returns a Highland stream fork. Deprecated, but
-//                              still the only thing the ~15 handlers in nymag/sites use, so it
-//                              stays until they are ported.
-//
-// `dispatch` feeds both, so a consumer can be moved from one to the other one at a time with no
-// flag and no coordinated release.
-//
-// Both APIs take an OPTIONAL `filter` predicate, which is the single largest efficiency win
-// available here. Every consumer gets its own deep clone of the payload for isolation, and for the
-// `save` topic that payload is the whole ops array -- so N consumers cloned N x (all ops) and then
-// each threw away the ~99% they did not want. Passing the predicate in lets the clone happen
-// *after* selection instead of before.
-//
-// Benchmarked on a real 67-op homepage publish delivered to 15 consumers (nymag/sites
-// .idea/highland-removal/bench): 1.4-2.7x less CPU per publish depending on payload shape, and it
-// works with the Highland fork still in place -- it does not require porting any consumer. The
-// saving is in object count, not bytes: `op.value` is a JSON string that cloneDeep shares by
-// reference, so what is avoided is allocating (and immediately discarding) one object per op per
-// consumer.
-//
-// Safe because selection strictly precedes mutation: the predicate only reads `op.key`/`op.value`,
-// and the first thing any consumer mutates is the clone. Omitting `filter` keeps the old
-// behaviour exactly, so this is backwards compatible for callers that do not pass one.
+// `dispatch` feeds both, so a consumer moves from one to the other on its own schedule.
 
 const _ = require('lodash'),
   h = require('highland'),
@@ -61,11 +39,13 @@ function stripNamespace(topic) {
 
 /**
  * Apply a consumer's own predicate before it gets its clone, so the clone covers only the ops it
- * actually wants. See the note at the top of this file for why this is the main win here.
+ * actually wants.
  *
- * Deliberately conservative: only filters when a predicate was supplied AND the payload is an
- * array. `save` and `delete` carry an ops array; every other topic carries a single object
- * (`unpublishPage` is `{ uri, url, user }`), and filtering those would be meaningless.
+ * Safe because selection strictly precedes mutation -- the predicate only reads the op, and the
+ * first thing a consumer mutates is its clone.
+ *
+ * Only filters an array, and only when a predicate was given. `save` and `delete` carry an ops
+ * array; every other topic carries a single object (`unpublishPage` is `{ uri, url, user }`).
  *
  * @param {Object|Array} payload
  * @param {Function} [filter] - `(op) => Boolean`, read-only
@@ -107,7 +87,7 @@ function assertKnownTopic(topic) {
  * @param {Function} handler - `(payload) => void|Promise`
  * @param {Function} [filter] - `(op) => Boolean`. When given, and the topic carries an ops array,
  *  this handler is cloned only the ops the predicate selects. Pass the same predicate the handler
- *  applies as its first stage; filtering twice is idempotent. See the note at the top of this file.
+ *  applies as its first stage; filtering twice is idempotent.
  * @throws {Error} on an unknown topic or a non-function handler
  */
 function on(topic, handler, filter) {
@@ -132,9 +112,8 @@ function on(topic, handler, filter) {
  *  Highland streams; remove once they are ported.
  * @param  {String} e
  * @param  {Function} [filter] - `(op) => Boolean`. When given, and the topic carries an ops array,
- *  this fork is cloned from only the ops the predicate selects instead of from all of them. Pass
- *  the same predicate the consumer applies as its first stage and the result is identical, because
- *  filtering twice is idempotent. See the note at the top of this file.
+ *  this fork is cloned from only the ops the predicate selects. Pass the same predicate the
+ *  consumer applies as its first stage; filtering twice is idempotent.
  * @return {Stream}
  */
 function subscribe(e, filter) {
@@ -197,7 +176,6 @@ function dispatch(topic, payload) {
 
   for (const { handler, filter } of handlers) {
     try {
-      // Filter before cloning, per handler -- see `select` and the note at the top of this file.
       const result = handler(_.cloneDeep(select(payload, filter)));
 
       if (result && typeof result.then === 'function') {

--- a/lib/streams.subscribe-filter.test.js
+++ b/lib/streams.subscribe-filter.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+// Filter-before-clone on the legacy `subscribe` fork.
+//
+// Deliberately a SEPARATE FILE from streams.test.js, because these are the only tests in the repo
+// that need the module-level Highland streams to be pristine, and streams.test.js permanently
+// breaks them:
+//
+//   - `lib['clay:save'].write = jest.fn()` (streams.test.js:155, :188, :221) assigns an own
+//     property over Highland's prototype method on a stream created once at require time and never
+//     recreated. Nothing restores it, so every later `dispatch('save', ...)` in that file writes to
+//     a stale mock instead of the real stream.
+//   - `lib.subscribe('save')` with no consumer (:154, :187, :220) leaves an unforked... rather, an
+//     unconsumed fork attached to the source. Highland forks share backpressure, so an unconsumed
+//     fork stalls the source for every other fork.
+//
+// Jest gives each test file its own module registry, so requiring streams.js here yields fresh
+// streams. The alternative -- teaching streams.test.js to save/restore `write` and to consume every
+// fork -- is the better long-term fix, but it means touching 30 passing tests to add coverage, so
+// it is left as a follow-up rather than bundled in here.
+
+const filename = 'streams',
+  lib = require('./' + filename),
+  OPS = [
+    { type: 'put', key: 'site.com/_components/article/instances/a@published', value: '{}' },
+    { type: 'put', key: 'site.com/_components/paragraph/instances/b@published', value: '{}' },
+    { type: 'put', key: 'site.com/_pages/p@published', value: '{}' }
+  ];
+
+/**
+ * @param {Object} op
+ * @returns {Boolean}
+ */
+function isArticleOp(op) {
+  return op.key.indexOf('/_components/article/') !== -1;
+}
+
+describe('streams subscribe filter-before-clone', () => {
+  // `save` forks emit a substream per event, so these flatten with `.sequence()` -- the same shape
+  // nymag/sites' handlers get from `.parallel(1)`. Consuming only the outer stream asserts on
+  // nothing, which is how an earlier version of these two tests silently observed empty arrays.
+  test('the fork is built from only the ops the predicate selects', () => {
+    const seen = [];
+
+    lib.subscribe('save', isArticleOp).sequence().each(op => seen.push(op));
+    lib.dispatch('save', OPS);
+
+    expect(seen).toEqual([OPS[0]]);
+  });
+
+  test('a predicate selecting nothing yields no ops rather than all of them', () => {
+    const seen = [];
+
+    lib.subscribe('delete', () => false).sequence().each(op => seen.push(op));
+    lib.dispatch('delete', OPS);
+
+    expect(seen).toEqual([]);
+  });
+
+  test('the fork still gets a clone, so mutating it cannot reach the payload', () => {
+    const payload = [{ type: 'put', key: 'site.com/_components/article/instances/a', value: '{}' }],
+      seen = [];
+
+    lib.subscribe('save', isArticleOp).sequence().each(op => {
+      op.value = 'MUTATED';
+      seen.push(op);
+    });
+    lib.dispatch('save', payload);
+
+    expect(seen).toHaveLength(1);
+    expect(payload[0].value).toBe('{}');
+  });
+});

--- a/lib/streams.test.js
+++ b/lib/streams.test.js
@@ -2,7 +2,33 @@
 
 const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
-  lib = require('./' + filename);
+  lib = require('./' + filename),
+  logMock = jest.fn();
+
+beforeEach(() => {
+  lib.reset();
+  lib.setLog(logMock);
+});
+
+/**
+ * A no-op handler, as a named function so the assertions below don't nest another arrow inside
+ * an `expect(() => ...)` and trip max-nested-callbacks.
+ */
+function noop() {}
+
+/**
+ * A handler that resolves on a later tick, used to show `dispatch` doesn't await. Declared at
+ * module scope for the same lint reason.
+ *
+ * @param {Object} flag - mutated to `{ resolved: true }` once the promise settles
+ * @returns {Function}
+ */
+function deferredHandler(flag) {
+  return () => new Promise(resolve => setImmediate(() => {
+    flag.resolved = true;
+    resolve();
+  }));
+}
 
 describe(filename, () => {
   describe('subscribe', () => {
@@ -11,10 +37,216 @@ describe(filename, () => {
     });
 
     test('it clones ops for save and delete to prefent mutations', () => {
+      // Restored in `finally`: this replaces cloneDeep on the shared lodash module, so leaving
+      // it mocked makes every later test in this file receive `undefined` wherever streams.js
+      // clones a payload.
+      const realCloneDeep = _.cloneDeep;
+
       _.cloneDeep = jest.fn(); // Mock the cloneDeep function
-      lib.subscribe('save').each(() => {}); // Make sure the stream is consumed
-      lib['clay:save'].write({}); // Write something to the stream
-      expect(_.cloneDeep).toHaveBeenCalled();
+
+      try {
+        lib.subscribe('save').each(() => {}); // Make sure the stream is consumed
+        lib['clay:save'].write({}); // Write something to the stream
+        expect(_.cloneDeep).toHaveBeenCalled();
+      } finally {
+        _.cloneDeep = realCloneDeep;
+      }
+    });
+  });
+
+  describe('on', () => {
+    test('throws on an event that is not in the BUS_TOPICS manifest', () => {
+      expect(() => lib.on('foo', noop)).toThrow(Error);
+    });
+
+    test('throws if the handler is not a function', () => {
+      expect(() => lib.on('save', 'not a function')).toThrow(Error);
+    });
+
+    test('registers a handler that dispatch then calls', () => {
+      const handler = jest.fn();
+
+      lib.on('save', handler);
+      lib.dispatch('save', [{ key: 'foo' }]);
+
+      expect(handler).toHaveBeenCalledWith([{ key: 'foo' }]);
+    });
+
+    test('calls every handler registered for a topic', () => {
+      const first = jest.fn(),
+        second = jest.fn();
+
+      lib.on('save', first);
+      lib.on('save', second);
+      lib.dispatch('save', ['op']);
+
+      expect(first).toHaveBeenCalled();
+      expect(second).toHaveBeenCalled();
+    });
+
+    test('does not call a handler registered for a different topic', () => {
+      const saveHandler = jest.fn();
+
+      lib.on('save', saveHandler);
+      lib.dispatch('unpublishPage', { uri: 'foo' });
+
+      expect(saveHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dispatch', () => {
+    test('throws on an unknown topic', () => {
+      expect(() => lib.dispatch('foo', {})).toThrow(Error);
+    });
+
+    // Each consumer gets its own copy, matching the per-fork cloneDeep `subscribe` does. Two
+    // handlers on one topic must not be able to see each other's mutations.
+    test('gives each handler its own deep clone of the payload', () => {
+      const payload = { nested: { count: 0 } };
+      let seenBySecond;
+
+      lib.on('saveMeta', received => { received.nested.count = 99; });
+      lib.on('saveMeta', received => { seenBySecond = received.nested.count; });
+      lib.dispatch('saveMeta', payload);
+
+      expect(seenBySecond).toBe(0);
+      expect(payload.nested.count).toBe(0);
+    });
+
+    test('a throwing handler is logged and does not stop the handlers after it', () => {
+      const after = jest.fn();
+
+      lib.on('save', () => { throw new Error('handler blew up'); });
+      lib.on('save', after);
+
+      expect(() => lib.dispatch('save', ['op'])).not.toThrow();
+      expect(after).toHaveBeenCalled();
+      expect(logMock).toHaveBeenCalled();
+    });
+
+    test('a rejecting handler is logged and does not surface to the caller', () => {
+      lib.on('save', () => Promise.reject(new Error('async handler failed')));
+
+      expect(() => lib.dispatch('save', ['op'])).not.toThrow();
+
+      // let the rejection settle before asserting on the log
+      return Promise.resolve().then(() => {
+        expect(logMock).toHaveBeenCalledWith(
+          'error',
+          expect.stringContaining('async handler failed'),
+          expect.any(Object)
+        );
+      });
+    });
+
+    test('does not wait for a handler that returns a promise', () => {
+      const flag = { resolved: false };
+
+      lib.on('save', deferredHandler(flag));
+      lib.dispatch('save', ['op']);
+
+      expect(flag.resolved).toBe(false);
+    });
+
+    test('writes to the legacy stream once something has forked it', () => {
+      const write = jest.fn();
+
+      lib.subscribe('save');
+      lib['clay:save'].write = write;
+      lib.dispatch('save', ['op']);
+
+      expect(write).toHaveBeenCalledWith(['op']);
+    });
+
+    // The behaviour change called out in dispatch's docblock: an unforked Highland stream
+    // buffers everything written to it for the life of the process, and the bus subscribes to
+    // every topic whether or not anyone consumes it.
+    test('does not write to a legacy stream nothing has forked', () => {
+      const write = jest.fn();
+
+      lib['clay:createPage'].write = write;
+      lib.dispatch('createPage', { uri: 'foo' });
+
+      expect(write).not.toHaveBeenCalled();
+    });
+
+    test('still reaches native handlers for a topic with no legacy fork', () => {
+      const handler = jest.fn();
+
+      lib.on('createPage', handler);
+      lib.dispatch('createPage', { uri: 'foo' });
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    test('feeds native handlers and the legacy stream from the same event', () => {
+      const handler = jest.fn(),
+        write = jest.fn();
+
+      lib.on('save', handler);
+      lib.subscribe('save');
+      lib['clay:save'].write = write;
+      lib.dispatch('save', ['op']);
+
+      expect(handler).toHaveBeenCalled();
+      expect(write).toHaveBeenCalled();
+    });
+  });
+
+  // The bus hands dispatch a namespaced topic (`clay:save`) because that is what it subscribed
+  // to, while BUS_TOPICS and the handler manifest use the bare name. Both must work everywhere.
+  describe('namespaced topics', () => {
+    test('dispatch accepts a namespaced topic for a bare registration', () => {
+      const handler = jest.fn();
+
+      lib.on('save', handler);
+      lib.dispatch('clay:save', ['op']);
+
+      expect(handler).toHaveBeenCalledWith(['op']);
+    });
+
+    test('on accepts a namespaced topic for a bare dispatch', () => {
+      const handler = jest.fn();
+
+      lib.on('clay:save', handler);
+      lib.dispatch('save', ['op']);
+
+      expect(handler).toHaveBeenCalledWith(['op']);
+    });
+
+    test('subscribe accepts a namespaced topic and forks the same stream', () => {
+      const write = jest.fn();
+
+      lib.subscribe('clay:save');
+      lib['clay:save'].write = write;
+      lib.dispatch('save', ['op']);
+
+      expect(write).toHaveBeenCalledWith(['op']);
+    });
+
+    test('stripNamespace leaves a bare topic alone', () => {
+      expect(lib.stripNamespace('save')).toBe('save');
+      expect(lib.stripNamespace('clay:save')).toBe('save');
+    });
+
+    test('a namespaced unknown topic still throws', () => {
+      expect(() => lib.dispatch('clay:nope', {})).toThrow(Error);
+    });
+  });
+
+  describe('hasSubscribers', () => {
+    test('is false for a topic nobody is listening to', () => {
+      expect(lib.hasSubscribers('delete')).toBe(false);
+    });
+
+    test('is true once a native handler is registered', () => {
+      lib.on('delete', noop);
+      expect(lib.hasSubscribers('delete')).toBe(true);
+    });
+
+    test('is true once the legacy stream is forked', () => {
+      lib.subscribe('delete');
+      expect(lib.hasSubscribers('delete')).toBe(true);
     });
   });
 });

--- a/lib/streams.test.js
+++ b/lib/streams.test.js
@@ -234,6 +234,89 @@ describe(filename, () => {
     });
   });
 
+  // Filter-before-clone. The efficiency win is that a consumer's clone covers only the ops it
+  // selected, but the contract that matters is that passing a filter cannot change WHAT a consumer
+  // sees versus filtering itself downstream -- so most of these assert equivalence, not speed.
+  describe('filter before clone', () => {
+    const OPS = [
+      { type: 'put', key: 'site.com/_components/article/instances/a@published', value: '{}' },
+      { type: 'put', key: 'site.com/_components/paragraph/instances/b@published', value: '{}' },
+      { type: 'put', key: 'site.com/_pages/p@published', value: '{}' }
+    ];
+
+    /**
+     * @param {Object} op
+     * @returns {Boolean}
+     */
+    function isArticleOp(op) {
+      return op.key.indexOf('/_components/article/') !== -1;
+    }
+
+    test('on: a handler with a filter only receives the ops it selected', () => {
+      const handler = jest.fn();
+
+      lib.on('save', handler, isArticleOp);
+      lib.dispatch('save', OPS);
+
+      expect(handler).toHaveBeenCalledWith([OPS[0]]);
+    });
+
+    test('on: a handler without a filter still receives everything', () => {
+      const handler = jest.fn();
+
+      lib.on('save', handler);
+      lib.dispatch('save', OPS);
+
+      expect(handler).toHaveBeenCalledWith(OPS);
+    });
+
+    test('on: filters are per-handler, not shared across a topic', () => {
+      const filtered = jest.fn(),
+        unfiltered = jest.fn();
+
+      lib.on('save', filtered, isArticleOp);
+      lib.on('save', unfiltered);
+      lib.dispatch('save', OPS);
+
+      expect(filtered.mock.calls[0][0]).toHaveLength(1);
+      expect(unfiltered.mock.calls[0][0]).toHaveLength(3);
+    });
+
+    // The isolation guarantee must survive the optimisation: a filtered handler still gets a clone,
+    // so mutating what it received cannot reach the original payload or another handler.
+    test('on: a filtered handler still gets a clone, not a view of the payload', () => {
+      const payload = [{ type: 'put', key: 'site.com/_components/article/instances/a', value: '{}' }];
+
+      lib.on('save', received => { received[0].value = 'MUTATED'; }, isArticleOp);
+      lib.dispatch('save', payload);
+
+      expect(payload[0].value).toBe('{}');
+    });
+
+    test('on: a filter selecting nothing yields an empty array, not the whole payload', () => {
+      const handler = jest.fn();
+
+      lib.on('save', handler, () => false);
+      lib.dispatch('save', OPS);
+
+      expect(handler).toHaveBeenCalledWith([]);
+    });
+
+    // `unpublishPage` and friends carry a single object; a stray filter must not corrupt them.
+    test('a filter is ignored for topics whose payload is not an array', () => {
+      const handler = jest.fn(),
+        msg = { uri: 'site.com/_pages/p', url: 'http://site.com/x' };
+
+      lib.on('unpublishPage', handler, isArticleOp);
+      lib.dispatch('unpublishPage', msg);
+
+      expect(handler).toHaveBeenCalledWith(msg);
+    });
+
+    // The `subscribe`-fork equivalents of these live in streams.subscribe-filter.test.js — they
+    // need pristine module-level Highland streams, which the tests above permanently mock out.
+  });
+
   describe('hasSubscribers', () => {
     test('is false for a topic nobody is listening to', () => {
       expect(lib.hasSubscribers('delete')).toBe(false);


### PR DESCRIPTION
Exports `on()` and `dispatch()` to carry events from the redis publish bus to consumers without
highland. Event handlers inside amphora-search change, but nothing downstream does -- `subscribe()`
is unchanged and the event bodies passed down are the same.

Keeps highland only as a compatibility layer if a downstream listener expects it, and avoids
writing to that stream unless it's forked so we don't leak memory there. Otherwise highland is
removed from amphora-search calls where it just wrapped a promise.
